### PR TITLE
Add GET /api/v1/properties/{property_id} endpoint to fetch property details by ID

### DIFF
--- a/services/main/docs/docs.go
+++ b/services/main/docs/docs.go
@@ -1027,7 +1027,13 @@ const docTemplate = `{
                     {
                         "type": "string",
                         "example": "550e8400-e29b-41d4-a716-446655440000",
-                        "name": "propertyID",
+                        "name": "property_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "example": "downtown-apartment-101",
+                        "name": "property_slug",
                         "in": "query"
                     },
                     {
@@ -1542,6 +1548,75 @@ const docTemplate = `{
                     },
                     "500": {
                         "description": "An unexpected error occurred",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/properties/{property_id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get property by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Properties"
+                ],
+                "summary": "Get property by ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Property ID",
+                        "name": "property_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "name": "populate",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "$ref": "#/definitions/transformations.OutputProperty"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "type": "string"
                         }

--- a/services/main/docs/swagger.json
+++ b/services/main/docs/swagger.json
@@ -1019,7 +1019,13 @@
                     {
                         "type": "string",
                         "example": "550e8400-e29b-41d4-a716-446655440000",
-                        "name": "propertyID",
+                        "name": "property_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "example": "downtown-apartment-101",
+                        "name": "property_slug",
                         "in": "query"
                     },
                     {
@@ -1534,6 +1540,75 @@
                     },
                     "500": {
                         "description": "An unexpected error occurred",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/properties/{property_id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get property by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Properties"
+                ],
+                "summary": "Get property by ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Property ID",
+                        "name": "property_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "name": "populate",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "$ref": "#/definitions/transformations.OutputProperty"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "type": "string"
                         }

--- a/services/main/docs/swagger.yaml
+++ b/services/main/docs/swagger.yaml
@@ -1279,7 +1279,11 @@ paths:
         type: array
       - example: 550e8400-e29b-41d4-a716-446655440000
         in: query
-        name: propertyID
+        name: property_id
+        type: string
+      - example: downtown-apartment-101
+        in: query
+        name: property_slug
         type: string
       - in: query
         name: query
@@ -1617,6 +1621,50 @@ paths:
       security:
       - BearerAuth: []
       summary: Creates a new property
+      tags:
+      - Properties
+  /api/v1/properties/{property_id}:
+    get:
+      consumes:
+      - application/json
+      description: Get property by ID
+      parameters:
+      - description: Property ID
+        in: path
+        name: property_id
+        required: true
+        type: string
+      - collectionFormat: csv
+        in: query
+        items:
+          type: string
+        name: populate
+        type: array
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            properties:
+              data:
+                $ref: '#/definitions/transformations.OutputProperty'
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "401":
+          description: Unauthorized
+          schema:
+            type: string
+        "500":
+          description: Internal Server Error
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Get property by ID
       tags:
       - Properties
 securityDefinitions:

--- a/services/main/internal/lib/list-resource-helper.go
+++ b/services/main/internal/lib/list-resource-helper.go
@@ -6,6 +6,10 @@ import (
 	"time"
 )
 
+type GetOneQueryInput struct {
+	Populate *[]string `json:"populate" validate:"omitempty"`
+}
+
 type FilterQueryInput struct {
 	Page         int       `json:"page"          validate:"gte=0"`
 	PageSize     int       `json:"page_size"     validate:"gte=0"`

--- a/services/main/internal/router/client-user.go
+++ b/services/main/internal/router/client-user.go
@@ -35,6 +35,10 @@ func NewClientUserRouter(appCtx pkg.AppContext, handlers handlers.Handlers) func
 			r.Route("/v1/properties", func(r chi.Router) {
 				r.Post("/", handlers.PropertyHandler.CreateProperty)
 				r.Get("/", handlers.PropertyHandler.ListProperties)
+
+				r.Route("/{property_id}", func(r chi.Router) {
+					r.Get("/", handlers.PropertyHandler.GetPropertyById)
+				})
 			})
 
 			r.Route("/v1/documents", func(r chi.Router) {

--- a/services/main/internal/services/property.go
+++ b/services/main/internal/services/property.go
@@ -21,6 +21,10 @@ type PropertyService interface {
 		context context.Context,
 		filterQuery repository.ListPropertiesFilter,
 	) (int64, error)
+	GetProperty(
+		context context.Context,
+		query repository.GetPropertyQuery,
+	) (*models.Property, error)
 }
 
 type propertyService struct {
@@ -168,4 +172,16 @@ func (s *propertyService) CountProperties(
 	}
 
 	return propertiesCount, nil
+}
+
+func (s *propertyService) GetProperty(
+	ctx context.Context,
+	query repository.GetPropertyQuery,
+) (*models.Property, error) {
+	property, err := s.repo.GetByID(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+
+	return property, nil
 }


### PR DESCRIPTION
## PR Name or Description

Add GET /api/v1/properties/{property_id} endpoint to fetch property details by ID

## Overview

This pull request introduces a new API endpoint that allows authenticated users to retrieve property details by property ID, with optional population of related fields.

## Detailed Technical Change

- Updated OpenAPI documentation (`docs.go`, `swagger.json`, `swagger.yaml`) to include the new endpoint and parameter changes (`property_id`, `property_slug`).
- Added `GetPropertyById` handler in `internal/handlers/property.go` to process GET requests for a single property.
- Introduced `GetOneQueryInput` struct in `internal/lib/list-resource-helper.go` for query validation.
- Modified repository interface and implementation in `internal/repository/property.go` to support fetching by ID with population.
- Updated service layer (`internal/services/property.go`) to add `GetProperty` method.
- Registered the new route in `internal/router/client-user.go`.

## Testing Approach

- Manual testing via HTTP requests to `/api/v1/properties/{property_id}` with and without the `populate` query parameter.
- Verified correct responses for valid, invalid, and unauthorised requests.
- Confirmed that related fields are populated when requested.
- All existing and new tests pass.

## Result
Fetching A Property With ID
<img width="1642" height="1002" alt="Screenshot 2025-11-03 at 1 34 28 PM" src="https://github.com/user-attachments/assets/6ef13a78-1cbe-43ce-a499-2272a88e5fdb" />

Fetching A Property With ID and Client Populate
<img width="1632" height="991" alt="Screenshot 2025-11-03 at 1 34 48 PM" src="https://github.com/user-attachments/assets/f88c41be-c146-4088-8436-d19d0696bcbe" />


## Related Work

N/A

## Documentation

- OpenAPI/Swagger documentation updated to reflect the new endpoint and parameter changes.
