### PR TITLE
Add Get Property By Slug Endpoint

### DIFF
--- a/services/main/docs/docs.go
+++ b/services/main/docs/docs.go
@@ -1555,6 +1555,81 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/properties/slug/{slug}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get property by slug",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Properties"
+                ],
+                "summary": "Get property by slug",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Property slug",
+                        "name": "slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "name": "populate",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Property of slug retrieved successfully",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "$ref": "#/definitions/transformations.OutputProperty"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Error occurred when fetching a property",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid or absent authentication token",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Property not found",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "An unexpected error occured",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/properties/{property_id}": {
             "get": {
                 "security": [

--- a/services/main/docs/swagger.json
+++ b/services/main/docs/swagger.json
@@ -1547,6 +1547,81 @@
                 }
             }
         },
+        "/api/v1/properties/slug/{slug}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get property by slug",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Properties"
+                ],
+                "summary": "Get property by slug",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Property slug",
+                        "name": "slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "name": "populate",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Property of slug retrieved successfully",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "$ref": "#/definitions/transformations.OutputProperty"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Error occurred when fetching a property",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid or absent authentication token",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Property not found",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "An unexpected error occured",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/properties/{property_id}": {
             "get": {
                 "security": [

--- a/services/main/docs/swagger.yaml
+++ b/services/main/docs/swagger.yaml
@@ -1807,6 +1807,54 @@ paths:
       summary: Update an existing property
       tags:
       - Properties
+  /api/v1/properties/slug/{slug}:
+    get:
+      consumes:
+      - application/json
+      description: Get property by slug
+      parameters:
+      - description: Property slug
+        in: path
+        name: slug
+        required: true
+        type: string
+      - collectionFormat: csv
+        in: query
+        items:
+          type: string
+        name: populate
+        type: array
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Property of slug retrieved successfully
+          schema:
+            properties:
+              data:
+                $ref: '#/definitions/transformations.OutputProperty'
+            type: object
+        "400":
+          description: Error occurred when fetching a property
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "401":
+          description: Invalid or absent authentication token
+          schema:
+            type: string
+        "404":
+          description: Property not found
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "500":
+          description: An unexpected error occured
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Get property by slug
+      tags:
+      - Properties
 securityDefinitions:
   BearerAuth:
     description: Type "Bearer" followed by a space and JWT token.

--- a/services/main/internal/router/client-user.go
+++ b/services/main/internal/router/client-user.go
@@ -35,6 +35,7 @@ func NewClientUserRouter(appCtx pkg.AppContext, handlers handlers.Handlers) func
 			r.Route("/v1/properties", func(r chi.Router) {
 				r.Post("/", handlers.PropertyHandler.CreateProperty)
 				r.Get("/", handlers.PropertyHandler.ListProperties)
+				r.Get("/slug/{slug}", handlers.PropertyHandler.GetPropertyBySlug)
 
 				r.Route("/{property_id}", func(r chi.Router) {
 					r.Get("/", handlers.PropertyHandler.GetPropertyById)


### PR DESCRIPTION
## PR Name or Description

Add Get Property By Slug Endpoint

## Overview

This pull request introduces a new API endpoint to retrieve property details by slug, including support for population of related fields.

## Detailed Technical Change

- Added `/api/v1/properties/slug/{slug}` GET route to the router.
- Implemented `GetPropertyBySlug` handler in `internal/handlers/property.go`.
- Defined `GetPropertyBySlugQuery` and repository method in `internal/repository/property.go`.
- Added service method in `internal/services/property.go`.
- Updated Swagger documentation (`docs.go`, `swagger.json`, `swagger.yaml`) to describe the new endpoint and its parameters/responses.

## Testing Approach

- Endpoint tested via HTTP requests with valid and invalid slugs.
- Verified correct property retrieval, error handling for not found, and query population.
- Swagger UI reflects the new endpoint and documentation.

## Result
<img width="1539" height="1004" alt="Screenshot 2025-11-05 at 8 57 57 PM" src="https://github.com/user-attachments/assets/39d7700f-2976-444c-a732-ea93b4c8f937" />

## Related Work

N/A

## Documentation

Swagger documentation updated for the new endpoint. 