### PR TITLE
Add GET /api/v1/client-users/{client_user_id} endpoint with populate support

### DIFF
--- a/services/main/docs/docs.go
+++ b/services/main/docs/docs.go
@@ -1057,6 +1057,75 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/client-users/{client_user_id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get client user with populate",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClientUsers"
+                ],
+                "summary": "Get client user with populate",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Client user ID",
+                        "name": "client_user_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "name": "populate",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Client user retrieved successfully",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "$ref": "#/definitions/transformations.OutputClientUser"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid or absent authentication token",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Client user not found",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "An unexpected error occurred",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/clients/apply": {
             "post": {
                 "description": "Create a new client application",

--- a/services/main/docs/swagger.json
+++ b/services/main/docs/swagger.json
@@ -1049,6 +1049,75 @@
                 }
             }
         },
+        "/api/v1/client-users/{client_user_id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get client user with populate",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClientUsers"
+                ],
+                "summary": "Get client user with populate",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Client user ID",
+                        "name": "client_user_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "name": "populate",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Client user retrieved successfully",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "$ref": "#/definitions/transformations.OutputClientUser"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid or absent authentication token",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Client user not found",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "An unexpected error occurred",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/clients/apply": {
             "post": {
                 "description": "Create a new client application",

--- a/services/main/docs/swagger.yaml
+++ b/services/main/docs/swagger.yaml
@@ -1282,6 +1282,50 @@ paths:
       summary: Creates new client user
       tags:
       - ClientUsers
+  /api/v1/client-users/{client_user_id}:
+    get:
+      consumes:
+      - application/json
+      description: Get client user with populate
+      parameters:
+      - description: Client user ID
+        in: path
+        name: client_user_id
+        required: true
+        type: string
+      - collectionFormat: csv
+        in: query
+        items:
+          type: string
+        name: populate
+        type: array
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Client user retrieved successfully
+          schema:
+            properties:
+              data:
+                $ref: '#/definitions/transformations.OutputClientUser'
+            type: object
+        "401":
+          description: Invalid or absent authentication token
+          schema:
+            type: string
+        "404":
+          description: Client user not found
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "500":
+          description: An unexpected error occurred
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Get client user with populate
+      tags:
+      - ClientUsers
   /api/v1/client-users/forgot-password:
     post:
       consumes:

--- a/services/main/internal/handlers/client-user.go
+++ b/services/main/internal/handlers/client-user.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Bendomey/rent-loop/services/main/internal/services"
 	"github.com/Bendomey/rent-loop/services/main/internal/transformations"
 	"github.com/Bendomey/rent-loop/services/main/pkg"
+	"github.com/go-chi/chi/v5"
 )
 
 type ClientUserHandler struct {
@@ -319,4 +320,49 @@ func (h *ClientUserHandler) ListClientUsers(w http.ResponseWriter, r *http.Reque
 
 	json.NewEncoder(w).
 		Encode(lib.ReturnListResponse(filterQuery, clientUsersTransformed, clientUsersCount))
+}
+
+type GetClientUserWithPopulateQuery struct {
+	lib.GetOneQueryInput
+}
+
+// @GetClientUserWithPopulate godoc
+// @Summary		Get client user with populate
+// @Description	Get client user with populate
+// @Tags			ClientUsers
+// @Accept			json
+// @Security		BearerAuth
+// @Produce		json
+// @Param			client_user_id	path		string				true	"Client user ID"
+// @Param			q				query		GetClientUserWithPopulateQuery	true	"Client user"
+// @Success		200				{object}	object{data=transformations.OutputClientUser} "Client user retrieved successfully"
+// @Failure		401				{object}	string			"Invalid or absent authentication token"
+// @Failure		404				{object}	lib.HTTPError	"Client user not found"
+// @Failure		500				{object}	string			"An unexpected error occurred"
+// @Router			/api/v1/client-users/{client_user_id} [get]
+func (c *ClientUserHandler) GetClientUserWithPopulate(w http.ResponseWriter, r *http.Request) {
+	currentClientUser, clientUserOk := lib.ClientUserFromContext(r.Context())
+	if !clientUserOk {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	populateFields := GetPopulateFields(r)
+
+	clientUserId := chi.URLParam(r, "client_user_id")
+
+	query := repository.GetClientUserWithPopulateQuery{
+		ID:       clientUserId,
+		ClientID: currentClientUser.ClientID,
+		Populate: populateFields,
+	}
+	clientUser, err := c.service.GetClientUserWithPopulate(r.Context(), query)
+	if err != nil {
+		HandleErrorResponse(w, err)
+		return
+	}
+
+	json.NewEncoder(w).Encode(map[string]any{
+		"data": transformations.DBClientUserToRest(clientUser),
+	})
 }

--- a/services/main/internal/router/client-user.go
+++ b/services/main/internal/router/client-user.go
@@ -35,6 +35,10 @@ func NewClientUserRouter(appCtx pkg.AppContext, handlers handlers.Handlers) func
 			)
 			r.Get("/v1/client-users", handlers.ClientUserHandler.ListClientUsers)
 
+			r.Route("/v1/client-users/{client_user_id}", func(r chi.Router) {
+				r.Get("/", handlers.ClientUserHandler.GetClientUserWithPopulate)
+			})
+
 			// properties
 			r.Route("/v1/properties", func(r chi.Router) {
 				r.With(middlewares.ValidateRoleClientUserMiddleware(appCtx, "ADMIN", "OWNER")).


### PR DESCRIPTION
## PR Name or Description

Add GET /api/v1/client-users/{client_user_id} endpoint with populate support

## Overview

This pull request introduces a new API endpoint to retrieve a client user by ID, with optional population of related fields. It includes handler, service, repository, and routing logic, as well as updates to API documentation.

## Detailed Technical Change

- Added `GetClientUserWithPopulate` handler in `internal/handlers/client-user.go`
- Defined `GetClientUserWithPopulateQuery` struct for query parameters
- Implemented `GetByIDWithPopulate` method in `internal/repository/client-user.go`
- Added corresponding service method in `internal/services/client-user.go`
- Registered the new route in `internal/router/client-user.go`
- Updated API documentation in `docs.go`, `swagger.json`, and `swagger.yaml`

## Testing Approach

- Manual testing via API client (e.g., Postman) to verify retrieval of client user with and without populated fields
- Confirmed correct HTTP status codes for success, unauthorised, not found, and error cases
- Verified response structure matches documentation

## Result
<img width="1480" height="1004" alt="Screenshot 2025-11-08 at 3 17 08 PM" src="https://github.com/user-attachments/assets/cbd8e203-0b55-4f51-8005-8aaaf754d56a" />

## Related Work

N/A

## Documentation

API documentation updated in `docs.go`, `swagger.json`, and `swagger.yaml` to reflect the new endpoint and its parameters.