### PR TITLE
Add support for "populate" query parameter to Document GET endpoint and enhance ClientApplication filtering

### DIFF
--- a/services/main/docs/docs.go
+++ b/services/main/docs/docs.go
@@ -390,6 +390,66 @@ const docTemplate = `{
                 "summary": "Get all ClientApplications",
                 "parameters": [
                     {
+                        "type": "string",
+                        "name": "end_date",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "asc",
+                            "desc"
+                        ],
+                        "type": "string",
+                        "name": "order",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "order_by",
+                        "in": "query"
+                    },
+                    {
+                        "minimum": 0,
+                        "type": "integer",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "minimum": 0,
+                        "type": "integer",
+                        "name": "page_size",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "name": "populate",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "query",
+                        "in": "query"
+                    },
+                    {
+                        "minItems": 1,
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "name": "search_fields",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "start_date",
+                        "in": "query"
+                    },
+                    {
                         "enum": [
                             "ClientApplication.Status.Pending",
                             "ClientApplication.Status.Approved",
@@ -1411,6 +1471,15 @@ const docTemplate = `{
                         "name": "document_id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "name": "populate",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/services/main/docs/swagger.json
+++ b/services/main/docs/swagger.json
@@ -382,6 +382,66 @@
                 "summary": "Get all ClientApplications",
                 "parameters": [
                     {
+                        "type": "string",
+                        "name": "end_date",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "asc",
+                            "desc"
+                        ],
+                        "type": "string",
+                        "name": "order",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "order_by",
+                        "in": "query"
+                    },
+                    {
+                        "minimum": 0,
+                        "type": "integer",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "minimum": 0,
+                        "type": "integer",
+                        "name": "page_size",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "name": "populate",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "query",
+                        "in": "query"
+                    },
+                    {
+                        "minItems": 1,
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "name": "search_fields",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "start_date",
+                        "in": "query"
+                    },
+                    {
                         "enum": [
                             "ClientApplication.Status.Pending",
                             "ClientApplication.Status.Approved",
@@ -1403,6 +1463,15 @@
                         "name": "document_id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "name": "populate",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/services/main/docs/swagger.yaml
+++ b/services/main/docs/swagger.yaml
@@ -967,6 +967,45 @@ paths:
       - application/json
       description: Get all ClientApplications
       parameters:
+      - in: query
+        name: end_date
+        type: string
+      - enum:
+        - asc
+        - desc
+        in: query
+        name: order
+        type: string
+      - in: query
+        name: order_by
+        type: string
+      - in: query
+        minimum: 0
+        name: page
+        type: integer
+      - in: query
+        minimum: 0
+        name: page_size
+        type: integer
+      - collectionFormat: csv
+        in: query
+        items:
+          type: string
+        name: populate
+        type: array
+      - in: query
+        name: query
+        type: string
+      - collectionFormat: csv
+        in: query
+        items:
+          type: string
+        minItems: 1
+        name: search_fields
+        type: array
+      - in: query
+        name: start_date
+        type: string
       - enum:
         - ClientApplication.Status.Pending
         - ClientApplication.Status.Approved
@@ -1656,6 +1695,12 @@ paths:
         name: document_id
         required: true
         type: string
+      - collectionFormat: csv
+        in: query
+        items:
+          type: string
+        name: populate
+        type: array
       produces:
       - application/json
       responses:

--- a/services/main/internal/handlers/client-application.go
+++ b/services/main/internal/handlers/client-application.go
@@ -232,6 +232,7 @@ func (h *ClientApplicationHandler) ApproveClientApplication(w http.ResponseWrite
 }
 
 type ListClientApplicationsFilterRequest struct {
+	lib.FilterQueryInput
 	Status  *string `json:"status"   validate:"omitempty,oneof=ClientApplication.Status.Pending ClientApplication.Status.Approved ClientApplication.Status.Rejected"`
 	Type    *string `json:"type"     validate:"omitempty,oneof=INDIVIDUAL COMPANY"`
 	SubType *string `json:"sub_type" validate:"omitempty,oneof=LANDLORD PROPERTY_MANAGER DEVELOPER AGENCY"`

--- a/services/main/internal/handlers/document.go
+++ b/services/main/internal/handlers/document.go
@@ -188,6 +188,10 @@ func (h *DocumentHandler) DeleteDocument(w http.ResponseWriter, r *http.Request)
 	w.WriteHeader(http.StatusNoContent)
 }
 
+type GetDocumentWithPopulateQuery struct {
+	lib.GetOneQueryInput
+}
+
 // GetDocumentById godoc
 //
 //	@Summary		Get document by ID
@@ -197,6 +201,7 @@ func (h *DocumentHandler) DeleteDocument(w http.ResponseWriter, r *http.Request)
 //	@Security		BearerAuth
 //	@Produce		json
 //	@Param			document_id	path		string	true	"Document ID"
+//	@Param			q				query		GetDocumentWithPopulateQuery	true	"Client user"
 //	@Success		200			{object}	object{data=transformations.OutputDocument}
 //	@Failure		400			{object}	lib.HTTPError
 //	@Failure		401			{object}	string
@@ -205,7 +210,14 @@ func (h *DocumentHandler) DeleteDocument(w http.ResponseWriter, r *http.Request)
 func (h *DocumentHandler) GetDocumentById(w http.ResponseWriter, r *http.Request) {
 	documentID := chi.URLParam(r, "document_id")
 
-	document, err := h.service.GetByID(r.Context(), documentID)
+	populateFields := GetPopulateFields(r)
+
+	filterQuery := repository.GetDocumentWithPopulateFilter{
+		ID:       documentID,
+		Populate: populateFields,
+	}
+
+	document, err := h.service.GetByIDWithPopulate(r.Context(), filterQuery)
 	if err != nil {
 		HandleErrorResponse(w, err)
 		return

--- a/services/main/internal/repository/document.go
+++ b/services/main/internal/repository/document.go
@@ -14,8 +14,20 @@ type DocumentRepository interface {
 	Create(context context.Context, document *models.Document) error
 	Update(context context.Context, document *models.Document) error
 	Delete(context context.Context, documentID string) error
-	List(context context.Context, filterQuery lib.FilterQuery, filters ListDocumentsFilter) (*[]models.Document, error)
-	Count(context context.Context, filterQuery lib.FilterQuery, filters ListDocumentsFilter) (int64, error)
+	List(
+		context context.Context,
+		filterQuery lib.FilterQuery,
+		filters ListDocumentsFilter,
+	) (*[]models.Document, error)
+	Count(
+		context context.Context,
+		filterQuery lib.FilterQuery,
+		filters ListDocumentsFilter,
+	) (int64, error)
+	GetByIDWithPopulate(
+		context context.Context,
+		query GetDocumentWithPopulateFilter,
+	) (*models.Document, error)
 }
 
 type documentRepository struct {
@@ -32,6 +44,32 @@ func (r *documentRepository) GetByID(ctx context.Context, id string) (*models.Do
 	if result.Error != nil {
 		return nil, result.Error
 	}
+	return &document, nil
+}
+
+type GetDocumentWithPopulateFilter struct {
+	ID       string
+	Populate *[]string
+}
+
+func (r *documentRepository) GetByIDWithPopulate(
+	ctx context.Context,
+	query GetDocumentWithPopulateFilter,
+) (*models.Document, error) {
+	var document models.Document
+	db := r.DB.WithContext(ctx).Where("id = ?", query.ID)
+
+	if query.Populate != nil {
+		for _, field := range *query.Populate {
+			db = db.Preload(field)
+		}
+	}
+
+	result := db.First(&document)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
 	return &document, nil
 }
 


### PR DESCRIPTION
## PR Name or Description

Add support for "populate" query parameter to Document GET endpoint and enhance ClientApplication filtering

## Overview

This pull request introduces the ability to populate related fields when fetching a document by ID using a new "populate" query parameter. It also extends the ClientApplication listing endpoint with additional query parameters for flexible filtering, ordering, and pagination.

## Detailed Technical Change

- Updated OpenAPI documentation (`docs.go`, `swagger.json`, `swagger.yaml`) to include new query parameters (`populate`, `end_date`, `order`, `order_by`, `page`, `page_size`, `query`, `search_fields`, `start_date`) for relevant endpoints.
- Added `FilterQueryInput` to `ListClientApplicationsFilterRequest` in `internal/handlers/client-application.go` for enhanced filtering.
- Introduced `GetDocumentWithPopulateQuery` and updated the `GetDocumentById` handler in `internal/handlers/document.go` to support the `populate` query parameter.
- Extended the `DocumentRepository` interface and implementation in `internal/repository/document.go` to support fetching documents with populated fields.
- Updated the `DocumentService` interface and implementation in `internal/services/documents.go` to handle the new repository method and error handling for populated queries.

## Testing Approach

- Manual API testing was performed using tools like Postman or curl to verify that the new query parameters are accepted and processed correctly.
- Verified that documents can be fetched with related fields populated by specifying the `populate` query parameter.
- Confirmed that ClientApplication listing supports new filtering and pagination options.
- All existing and new functionality returned expected results without errors.

## Results
Get Client Applications rendering queries
<img width="1488" height="1003" alt="Screenshot 2025-11-11 at 5 37 53 PM" src="https://github.com/user-attachments/assets/4917a4e2-94ef-46b6-afa1-fb72c9a237b9" />

Fetching document by id with populate
<img width="1555" height="1003" alt="Screenshot 2025-11-11 at 5 42 02 PM" src="https://github.com/user-attachments/assets/0464743c-25ca-41e6-bc6c-2d0539b7aa3f" />

## Related Work

N/A

## Documentation

- OpenAPI documentation updated in `docs.go`, `swagger.json`, and `swagger.yaml` to reflect new query parameters and endpoint capabilities.