### PR TITLE
Add an API endpoint to link a client user to multiple properties with role assignment

### DIFF
--- a/services/main/docs/docs.go
+++ b/services/main/docs/docs.go
@@ -1186,6 +1186,67 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/client-users/{client_user_id}/properties:link": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Link client user to properties",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClientUserProperties"
+                ],
+                "summary": "Link client user to properties",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Client user ID",
+                        "name": "client_user_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Link Client User To Properties Request Body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.LinkClientUserToPropertiesRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Client user linked to properties successfully"
+                    },
+                    "400": {
+                        "description": "Invalid request body",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error occured",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "An unexpected error occurred",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/clients/apply": {
             "post": {
                 "description": "Create a new client application",
@@ -2529,6 +2590,33 @@ const docTemplate = `{
                         "MULTI"
                     ],
                     "example": "SINGLE"
+                }
+            }
+        },
+        "handlers.LinkClientUserToPropertiesRequest": {
+            "type": "object",
+            "required": [
+                "property_ids",
+                "role"
+            ],
+            "properties": {
+                "property_ids": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "a8098c1a-f86e-11da-bd1a-00112444be1e"
+                    ]
+                },
+                "role": {
+                    "type": "string",
+                    "enum": [
+                        "MANAGER",
+                        "STAFF"
+                    ],
+                    "example": "MANAGER"
                 }
             }
         },

--- a/services/main/docs/swagger.json
+++ b/services/main/docs/swagger.json
@@ -1178,6 +1178,67 @@
                 }
             }
         },
+        "/api/v1/client-users/{client_user_id}/properties:link": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Link client user to properties",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClientUserProperties"
+                ],
+                "summary": "Link client user to properties",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Client user ID",
+                        "name": "client_user_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Link Client User To Properties Request Body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.LinkClientUserToPropertiesRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Client user linked to properties successfully"
+                    },
+                    "400": {
+                        "description": "Invalid request body",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error occured",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "An unexpected error occurred",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/clients/apply": {
             "post": {
                 "description": "Create a new client application",
@@ -2521,6 +2582,33 @@
                         "MULTI"
                     ],
                     "example": "SINGLE"
+                }
+            }
+        },
+        "handlers.LinkClientUserToPropertiesRequest": {
+            "type": "object",
+            "required": [
+                "property_ids",
+                "role"
+            ],
+            "properties": {
+                "property_ids": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "a8098c1a-f86e-11da-bd1a-00112444be1e"
+                    ]
+                },
+                "role": {
+                    "type": "string",
+                    "enum": [
+                        "MANAGER",
+                        "STAFF"
+                    ],
+                    "example": "MANAGER"
                 }
             }
         },

--- a/services/main/docs/swagger.yaml
+++ b/services/main/docs/swagger.yaml
@@ -213,6 +213,25 @@ definitions:
     - status
     - type
     type: object
+  handlers.LinkClientUserToPropertiesRequest:
+    properties:
+      property_ids:
+        example:
+        - a8098c1a-f86e-11da-bd1a-00112444be1e
+        items:
+          type: string
+        minItems: 1
+        type: array
+      role:
+        enum:
+        - MANAGER
+        - STAFF
+        example: MANAGER
+        type: string
+    required:
+    - property_ids
+    - role
+    type: object
   handlers.LoginClientUserRequest:
     properties:
       email:
@@ -1365,6 +1384,45 @@ paths:
       summary: Get client user with populate
       tags:
       - ClientUsers
+  /api/v1/client-users/{client_user_id}/properties:link:
+    post:
+      consumes:
+      - application/json
+      description: Link client user to properties
+      parameters:
+      - description: Client user ID
+        in: path
+        name: client_user_id
+        required: true
+        type: string
+      - description: Link Client User To Properties Request Body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.LinkClientUserToPropertiesRequest'
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: Client user linked to properties successfully
+        "400":
+          description: Invalid request body
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "422":
+          description: Validation error occured
+          schema:
+            type: string
+        "500":
+          description: An unexpected error occurred
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Link client user to properties
+      tags:
+      - ClientUserProperties
   /api/v1/client-users/forgot-password:
     post:
       consumes:

--- a/services/main/internal/handlers/client-user-property.go
+++ b/services/main/internal/handlers/client-user-property.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Bendomey/rent-loop/services/main/internal/services"
 	"github.com/Bendomey/rent-loop/services/main/internal/transformations"
 	"github.com/Bendomey/rent-loop/services/main/pkg"
+	"github.com/go-chi/chi/v5"
 )
 
 type ClientUserPropertyHandler struct {
@@ -91,4 +92,59 @@ func (h *ClientUserPropertyHandler) ListClientUserProperties(w http.ResponseWrit
 	}
 
 	json.NewEncoder(w).Encode(lib.ReturnListResponse(filterQuery, clientUserPropertiesTransformed, count))
+}
+
+type LinkClientUserToPropertiesRequest struct {
+	PropertyIDs []string `json:"property_ids" validate:"required,min=1,dive,uuid4"    example:"a8098c1a-f86e-11da-bd1a-00112444be1e" description:"List of property UUIDs to link"`
+	Role        string   `json:"role"         validate:"required,oneof=MANAGER STAFF" example:"MANAGER"                              description:"Role of the client user for the properties (MANAGER or STAFF)"`
+}
+
+// LinkClientUserToProperties godoc
+//
+//	@Summary		Link client user to properties
+//	@Description	Link client user to properties
+//	@Tags			ClientUserProperties
+//	@Accept			json
+//	@Security		BearerAuth
+//	@Produce		json
+//	@Param			client_user_id	path		string								true	"Client user ID"
+//	@Param			body			body		LinkClientUserToPropertiesRequest	true	"Link Client User To Properties Request Body"
+//	@Success		204				{object}	nil									"Client user linked to properties successfully"
+//	@Failure		400				{object}	lib.HTTPError						"Invalid request body"
+//	@Failure		422				{object}	string								"Validation error occured"
+//	@Failure		500				{object}	string								"An unexpected error occurred"
+//	@Router			/api/v1/client-users/{client_user_id}/properties:link [post]
+func (h *ClientUserPropertyHandler) ListClientUserToProperties(w http.ResponseWriter, r *http.Request) {
+	clientUser, clientUserOk := lib.ClientUserFromContext(r.Context())
+	if !clientUserOk {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	clientUserId := chi.URLParam(r, "client_user_id")
+	var body LinkClientUserToPropertiesRequest
+	if decodeErr := json.NewDecoder(r.Body).Decode(&body); decodeErr != nil {
+		http.Error(w, "Invalid JSON body", http.StatusUnprocessableEntity)
+		return
+	}
+
+	isPassedValidation := lib.ValidateRequest(h.appCtx.Validator, body, w)
+	if !isPassedValidation {
+		return
+	}
+
+	input := services.LinkClientUserToPropertiesInput{
+		PropertyIDs:  body.PropertyIDs,
+		Role:         body.Role,
+		ClientUserID: clientUserId,
+		CreatedByID:  clientUser.ID,
+	}
+
+	linkClientUserToPropertiesErr := h.service.LinkClientUserToProperties(r.Context(), input)
+	if linkClientUserToPropertiesErr != nil {
+		HandleErrorResponse(w, linkClientUserToPropertiesErr)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/services/main/internal/repository/client-user-property.go
+++ b/services/main/internal/repository/client-user-property.go
@@ -20,6 +20,7 @@ type ClientUserPropertyRepository interface {
 		ctx context.Context,
 		filterQuery ListClientUserPropertiesFilter,
 	) (int64, error)
+	BulkCreate(ctx context.Context, clientUserProperty *[]models.ClientUserProperty) error
 }
 
 type clientUserPropertyRepository struct {
@@ -37,6 +38,15 @@ func (r *clientUserPropertyRepository) Create(
 	db := lib.ResolveDB(ctx, r.DB)
 
 	return db.WithContext(ctx).Create(clientUserProperty).Error
+}
+
+func (r *clientUserPropertyRepository) BulkCreate(
+	ctx context.Context,
+	clientUserProperties *[]models.ClientUserProperty,
+) error {
+	db := lib.ResolveDB(ctx, r.DB)
+
+	return db.WithContext(ctx).Create(clientUserProperties).Error
 }
 
 func (r *clientUserPropertyRepository) DeleteByPropertyID(

--- a/services/main/internal/router/client-user.go
+++ b/services/main/internal/router/client-user.go
@@ -37,6 +37,8 @@ func NewClientUserRouter(appCtx pkg.AppContext, handlers handlers.Handlers) func
 
 			r.Route("/v1/client-users/{client_user_id}", func(r chi.Router) {
 				r.Get("/", handlers.ClientUserHandler.GetClientUserWithPopulate)
+				r.With(middlewares.ValidateRoleClientUserMiddleware(appCtx, "ADMIN", "OWNER")).
+					Post("/properties:link", handlers.ClientUserPropertyHandler.ListClientUserToProperties)
 			})
 
 			// properties


### PR DESCRIPTION
## PR Name or Description

Add an API endpoint to link a client user to multiple properties with role assignment

## Overview

This pull request introduces a new API endpoint that allows linking a client user to multiple properties with a specified role (MANAGER or STAFF). It includes backend logic, request validation, repository bulk creation, and updates to OpenAPI documentation.

## Detailed Technical Change

- Added `LinkClientUserToPropertiesRequest` struct and handler in `internal/handlers/client-user-property.go`
- Implemented `BulkCreate` method in `internal/repository/client-user-property.go`
- Added `LinkClientUserToProperties` service method and input struct in `internal/services/client-user-property.go`
- Registered new route in `internal/router/client-user.go` with role-based middleware
- Updated OpenAPI documentation in `docs.go`, `swagger.json`, and `swagger.yaml` to describe the new endpoint and request schema

## Testing Approach

- Manual testing via API client (e.g., Postman) to POST `/api/v1/client-users/{client_user_id}/properties:link` with valid/invalid payloads
- Verified correct linking of properties and role assignment in the database
- Confirmed proper error handling for validation, authorisation, and server errors

## Result
Request body to link client user to properties
<img width="1593" height="1005" alt="Screenshot 2025-11-11 at 10 59 58 PM" src="https://github.com/user-attachments/assets/6b908851-0afd-4f89-b3fa-c0bfb178cf1a" />

204 No Content response indicates linking successful
<img width="1502" height="1005" alt="Screenshot 2025-11-11 at 10 29 21 PM" src="https://github.com/user-attachments/assets/e0c10f56-00ef-4674-8b1c-02a6131f495f" />

The linked property displayed amongst client user's properties
<img width="1555" height="1003" alt="Screenshot 2025-11-11 at 5 42 02 PM" src="https://github.com/user-attachments/assets/81dc6992-2367-407c-879e-e8bc8e425ac3" />

## Related Work

N/A

## Documentation

OpenAPI docs updated in `docs.go`, `swagger.json`, and `swagger.yaml` to reflect the new endpoint and request schema.