### PR TITLE
Improve Swagger Documentation Formatting for API Handlers by running make lint-fix

### DIFF
--- a/services/main/internal/handlers/client-user.go
+++ b/services/main/internal/handlers/client-user.go
@@ -326,20 +326,21 @@ type GetClientUserWithPopulateQuery struct {
 	lib.GetOneQueryInput
 }
 
-// @GetClientUserWithPopulate godoc
-// @Summary		Get client user with populate
-// @Description	Get client user with populate
-// @Tags			ClientUsers
-// @Accept			json
-// @Security		BearerAuth
-// @Produce		json
-// @Param			client_user_id	path		string				true	"Client user ID"
-// @Param			q				query		GetClientUserWithPopulateQuery	true	"Client user"
-// @Success		200				{object}	object{data=transformations.OutputClientUser} "Client user retrieved successfully"
-// @Failure		401				{object}	string			"Invalid or absent authentication token"
-// @Failure		404				{object}	lib.HTTPError	"Client user not found"
-// @Failure		500				{object}	string			"An unexpected error occurred"
-// @Router			/api/v1/client-users/{client_user_id} [get]
+// GetClientUserWithPopulate	godoc
+//
+//	@Summary		Get client user with populate
+//	@Description	Get client user with populate
+//	@Tags			ClientUsers
+//	@Accept			json
+//	@Security		BearerAuth
+//	@Produce		json
+//	@Param			client_user_id	path		string											true	"Client user ID"
+//	@Param			q				query		GetClientUserWithPopulateQuery					true	"Client user"
+//	@Success		200				{object}	object{data=transformations.OutputClientUser}	"Client user retrieved successfully"
+//	@Failure		401				{object}	string											"Invalid or absent authentication token"
+//	@Failure		404				{object}	lib.HTTPError									"Client user not found"
+//	@Failure		500				{object}	string											"An unexpected error occurred"
+//	@Router			/api/v1/client-users/{client_user_id} [get]
 func (c *ClientUserHandler) GetClientUserWithPopulate(w http.ResponseWriter, r *http.Request) {
 	currentClientUser, clientUserOk := lib.ClientUserFromContext(r.Context())
 	if !clientUserOk {

--- a/services/main/internal/handlers/document.go
+++ b/services/main/internal/handlers/document.go
@@ -200,8 +200,8 @@ type GetDocumentWithPopulateQuery struct {
 //	@Accept			json
 //	@Security		BearerAuth
 //	@Produce		json
-//	@Param			document_id	path		string	true	"Document ID"
-//	@Param			q				query		GetDocumentWithPopulateQuery	true	"Client user"
+//	@Param			document_id	path		string							true	"Document ID"
+//	@Param			q			query		GetDocumentWithPopulateQuery	true	"Client user"
 //	@Success		200			{object}	object{data=transformations.OutputDocument}
 //	@Failure		400			{object}	lib.HTTPError
 //	@Failure		401			{object}	string


### PR DESCRIPTION
- In `client-user.go`, the Swagger (OpenAPI) comments for the `GetClientUserWithPopulate` endpoint are reformatted for better readability and consistency, adjusting indentation and spacing.

- In `document.go`, the Swagger comments for the `GetDocumentWithPopulate` endpoint are similarly updated, improving parameter alignment and formatting.

