### PR TITLE
Add Unlink Client User from Properties API Endpoint

### DIFF
--- a/services/main/docs/docs.go
+++ b/services/main/docs/docs.go
@@ -1247,6 +1247,55 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/client-users/{client_user_id}/properties:unlink": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Unlink client user from properties",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClientUserProperties"
+                ],
+                "summary": "Unlink client user from properties",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Client user ID",
+                        "name": "client_user_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Unlink Client User From Properties Request Body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.UnlinkClientUserFromPropertyRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Client user unlinked from properties successfully"
+                    },
+                    "500": {
+                        "description": "An unexpected error occurred",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/clients/apply": {
             "post": {
                 "description": "Create a new client application",
@@ -2690,6 +2739,24 @@ const docTemplate = `{
                 "email": {
                     "type": "string",
                     "example": "client-user@example.com"
+                }
+            }
+        },
+        "handlers.UnlinkClientUserFromPropertyRequest": {
+            "type": "object",
+            "required": [
+                "property_ids"
+            ],
+            "properties": {
+                "property_ids": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "a8098c1a-f86e-11da-bd1a-00112444be1e"
+                    ]
                 }
             }
         },

--- a/services/main/docs/swagger.json
+++ b/services/main/docs/swagger.json
@@ -1239,6 +1239,55 @@
                 }
             }
         },
+        "/api/v1/client-users/{client_user_id}/properties:unlink": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Unlink client user from properties",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClientUserProperties"
+                ],
+                "summary": "Unlink client user from properties",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Client user ID",
+                        "name": "client_user_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Unlink Client User From Properties Request Body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.UnlinkClientUserFromPropertyRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Client user unlinked from properties successfully"
+                    },
+                    "500": {
+                        "description": "An unexpected error occurred",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/clients/apply": {
             "post": {
                 "description": "Create a new client application",
@@ -2682,6 +2731,24 @@
                 "email": {
                     "type": "string",
                     "example": "client-user@example.com"
+                }
+            }
+        },
+        "handlers.UnlinkClientUserFromPropertyRequest": {
+            "type": "object",
+            "required": [
+                "property_ids"
+            ],
+            "properties": {
+                "property_ids": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "a8098c1a-f86e-11da-bd1a-00112444be1e"
+                    ]
                 }
             }
         },

--- a/services/main/docs/swagger.yaml
+++ b/services/main/docs/swagger.yaml
@@ -283,6 +283,18 @@ definitions:
     required:
     - email
     type: object
+  handlers.UnlinkClientUserFromPropertyRequest:
+    properties:
+      property_ids:
+        example:
+        - a8098c1a-f86e-11da-bd1a-00112444be1e
+        items:
+          type: string
+        minItems: 1
+        type: array
+    required:
+    - property_ids
+    type: object
   handlers.UpdateDocumentRequest:
     properties:
       content:
@@ -1421,6 +1433,37 @@ paths:
       security:
       - BearerAuth: []
       summary: Link client user to properties
+      tags:
+      - ClientUserProperties
+  /api/v1/client-users/{client_user_id}/properties:unlink:
+    delete:
+      consumes:
+      - application/json
+      description: Unlink client user from properties
+      parameters:
+      - description: Client user ID
+        in: path
+        name: client_user_id
+        required: true
+        type: string
+      - description: Unlink Client User From Properties Request Body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.UnlinkClientUserFromPropertyRequest'
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: Client user unlinked from properties successfully
+        "500":
+          description: An unexpected error occurred
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Unlink client user from properties
       tags:
       - ClientUserProperties
   /api/v1/client-users/forgot-password:

--- a/services/main/internal/router/client-user.go
+++ b/services/main/internal/router/client-user.go
@@ -38,7 +38,9 @@ func NewClientUserRouter(appCtx pkg.AppContext, handlers handlers.Handlers) func
 			r.Route("/v1/client-users/{client_user_id}", func(r chi.Router) {
 				r.Get("/", handlers.ClientUserHandler.GetClientUserWithPopulate)
 				r.With(middlewares.ValidateRoleClientUserMiddleware(appCtx, "ADMIN", "OWNER")).
-					Post("/properties:link", handlers.ClientUserPropertyHandler.ListClientUserToProperties)
+					Post("/properties:link", handlers.ClientUserPropertyHandler.LinkClientUserToProperties)
+				r.With(middlewares.ValidateRoleClientUserMiddleware(appCtx, "ADMIN", "OWNER")).
+					Delete("/properties:unlink", handlers.ClientUserPropertyHandler.UnlinkClientUserFromProperties)
 			})
 
 			// properties

--- a/services/main/internal/services/client-user-property.go
+++ b/services/main/internal/services/client-user-property.go
@@ -23,6 +23,7 @@ type ClientUserPropertyService interface {
 		filterQuery repository.ListClientUserPropertiesFilter,
 	) (int64, error)
 	LinkClientUserToProperties(context context.Context, input LinkClientUserToPropertiesInput) error
+	UnlinkByClientUserID(context context.Context, input repository.UnlinkClientUserFromPropertyQuery) error
 }
 
 type clientUserPropertyService struct {
@@ -120,6 +121,24 @@ func (s *clientUserPropertyService) UnlinkByPropertyID(
 			},
 		})
 	}
+	return nil
+}
+
+func (s *clientUserPropertyService) UnlinkByClientUserID(
+	ctx context.Context,
+	input repository.UnlinkClientUserFromPropertyQuery,
+) error {
+	unlinkErr := s.repo.DeleteByClientUserID(ctx, input)
+	if unlinkErr != nil {
+		return pkg.InternalServerError(unlinkErr.Error(), &pkg.RentLoopErrorParams{
+			Err: unlinkErr,
+			Metadata: map[string]string{
+				"function": "UnlinkByClientUserID",
+				"action":   "deleting client user property links",
+			},
+		})
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## PR Name or Description

Add Unlink Client User from Properties API Endpoint

## Overview

This pull request introduces a new API endpoint to allow unlinking properties from a client user. It includes handler, service, repository, and documentation updates to support this functionality.

## Detailed Technical Change

- Added `UnlinkClientUserFromPropertyRequest` struct with validation and documentation tags in `internal/handlers/client-user-property.go`.
- Implemented `UnlinkClientUserFromProperties` handler method.
- Updated repository interface and implementation to support unlinking by client user and property IDs in `internal/repository/client-user-property.go`.
- Added corresponding service method in `internal/services/client-user-property.go`.
- Registered the new endpoint in the router (`internal/router/client-user.go`).
- Updated OpenAPI documentation in `docs.go`, `swagger.json`, and `swagger.yaml` to describe the new endpoint and request schema.

## Testing Approach

- Manual API testing using HTTP requests to the new endpoint (`DELETE /api/v1/client-users/{client_user_id}/properties:unlink`) with valid and invalid payloads.
- Verified correct unlinking of properties and appropriate error handling.
- Confirmed OpenAPI documentation renders the new endpoint and schema.

## Result
Properties owned by Client User before unlinking
<img width="1534" height="1001" alt="Screenshot 2025-11-12 at 5 59 05 PM" src="https://github.com/user-attachments/assets/f331ae9b-58c7-430c-ba64-8280bb596b7a" />

Property unlinked from the client user
<img width="1520" height="1004" alt="Screenshot 2025-11-12 at 6 34 23 PM" src="https://github.com/user-attachments/assets/8d3d57bf-0a33-4be3-8935-bc60f801fe72" />

Properties owned after unlinking
<img width="1489" height="1005" alt="Screenshot 2025-11-12 at 5 59 16 PM" src="https://github.com/user-attachments/assets/63c95b07-8f04-487d-9f58-9ea6ab4d943f" />

## Related Work

N/A

## Documentation

- Updated API documentation in `docs.go`, `swagger.json`, and `swagger.yaml` to include the new endpoint and request schema.