### PR TITLE
Add endpoint to link a property to multiple client users with role assignment

### DIFF
--- a/services/main/docs/docs.go
+++ b/services/main/docs/docs.go
@@ -1287,6 +1287,12 @@ const docTemplate = `{
                     "204": {
                         "description": "Client user unlinked from properties successfully"
                     },
+                    "422": {
+                        "description": "Validation error occured",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
                     "500": {
                         "description": "An unexpected error occurred",
                         "schema": {
@@ -2352,6 +2358,61 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/api/v1/properties/{property_id}/client-users:link": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Link property to client users",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClientUserProperties"
+                ],
+                "summary": "Link property to client users",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Property ID",
+                        "name": "property_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Link Property To Client Users Request Body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.LinkPropertyToClientUsersRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Property linked to client users successfully"
+                    },
+                    "422": {
+                        "description": "Validation error occured",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "An unexpected error occurred",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -2650,6 +2711,33 @@ const docTemplate = `{
             ],
             "properties": {
                 "property_ids": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "a8098c1a-f86e-11da-bd1a-00112444be1e"
+                    ]
+                },
+                "role": {
+                    "type": "string",
+                    "enum": [
+                        "MANAGER",
+                        "STAFF"
+                    ],
+                    "example": "MANAGER"
+                }
+            }
+        },
+        "handlers.LinkPropertyToClientUsersRequest": {
+            "type": "object",
+            "required": [
+                "client_user_ids",
+                "role"
+            ],
+            "properties": {
+                "client_user_ids": {
                     "type": "array",
                     "minItems": 1,
                     "items": {

--- a/services/main/docs/swagger.json
+++ b/services/main/docs/swagger.json
@@ -1279,6 +1279,12 @@
                     "204": {
                         "description": "Client user unlinked from properties successfully"
                     },
+                    "422": {
+                        "description": "Validation error occured",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
                     "500": {
                         "description": "An unexpected error occurred",
                         "schema": {
@@ -2344,6 +2350,61 @@
                     }
                 }
             }
+        },
+        "/api/v1/properties/{property_id}/client-users:link": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Link property to client users",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClientUserProperties"
+                ],
+                "summary": "Link property to client users",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Property ID",
+                        "name": "property_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Link Property To Client Users Request Body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.LinkPropertyToClientUsersRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Property linked to client users successfully"
+                    },
+                    "422": {
+                        "description": "Validation error occured",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "An unexpected error occurred",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -2642,6 +2703,33 @@
             ],
             "properties": {
                 "property_ids": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "a8098c1a-f86e-11da-bd1a-00112444be1e"
+                    ]
+                },
+                "role": {
+                    "type": "string",
+                    "enum": [
+                        "MANAGER",
+                        "STAFF"
+                    ],
+                    "example": "MANAGER"
+                }
+            }
+        },
+        "handlers.LinkPropertyToClientUsersRequest": {
+            "type": "object",
+            "required": [
+                "client_user_ids",
+                "role"
+            ],
+            "properties": {
+                "client_user_ids": {
                     "type": "array",
                     "minItems": 1,
                     "items": {

--- a/services/main/docs/swagger.yaml
+++ b/services/main/docs/swagger.yaml
@@ -232,6 +232,25 @@ definitions:
     - property_ids
     - role
     type: object
+  handlers.LinkPropertyToClientUsersRequest:
+    properties:
+      client_user_ids:
+        example:
+        - a8098c1a-f86e-11da-bd1a-00112444be1e
+        items:
+          type: string
+        minItems: 1
+        type: array
+      role:
+        enum:
+        - MANAGER
+        - STAFF
+        example: MANAGER
+        type: string
+    required:
+    - client_user_ids
+    - role
+    type: object
   handlers.LoginClientUserRequest:
     properties:
       email:
@@ -1457,6 +1476,10 @@ paths:
       responses:
         "204":
           description: Client user unlinked from properties successfully
+        "422":
+          description: Validation error occured
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
         "500":
           description: An unexpected error occurred
           schema:
@@ -2131,6 +2154,41 @@ paths:
       summary: Update an existing property
       tags:
       - Properties
+  /api/v1/properties/{property_id}/client-users:link:
+    post:
+      consumes:
+      - application/json
+      description: Link property to client users
+      parameters:
+      - description: Property ID
+        in: path
+        name: property_id
+        required: true
+        type: string
+      - description: Link Property To Client Users Request Body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.LinkPropertyToClientUsersRequest'
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: Property linked to client users successfully
+        "422":
+          description: Validation error occured
+          schema:
+            type: string
+        "500":
+          description: An unexpected error occurred
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Link property to client users
+      tags:
+      - ClientUserProperties
   /api/v1/properties/me:
     get:
       consumes:

--- a/services/main/internal/router/client-user.go
+++ b/services/main/internal/router/client-user.go
@@ -61,6 +61,8 @@ func NewClientUserRouter(appCtx pkg.AppContext, handlers handlers.Handlers) func
 						Patch("/", handlers.PropertyHandler.UpdateProperty)
 					r.With(middlewares.ValidateRoleClientUserMiddleware(appCtx, "ADMIN", "OWNER")).
 						Delete("/", handlers.PropertyHandler.DeleteProperty)
+					r.With(middlewares.ValidateRoleClientUserMiddleware(appCtx, "ADMIN", "OWNER")).
+						Post("/client-users:link", handlers.ClientUserPropertyHandler.LinkPropertyToClientUsers)
 				})
 			})
 


### PR DESCRIPTION
## PR Name or Description

Add endpoint to link a property to multiple client users with role assignment

## Overview

This PR introduces a new API endpoint that allows linking a property to multiple client users, specifying their roles (MANAGER or STAFF). It includes request validation, service logic, and updates to documentation.

## Detailed Technical Change

- Added LinkPropertyToClientUsersRequest struct and handler in internal/handlers/client-user-property.go
- Implemented LinkPropertyToClientUsers method in ClientUserPropertyService (internal/services/client-user-property.go)
- Registered the new POST /api/v1/properties/{property_id}/client-users:link route in internal/router/client-user.go
- Updated OpenAPI documentation in docs.go, swagger.json, and swagger.yaml to describe the new endpoint and request schema

## Testing Approach

- Manual testing via API client (e.g., Postman) to POST to /api/v1/properties/{property_id}/client-users:link with valid/invalid payloads
- Verified correct status codes: 204 for success, 422 for validation errors, 500 for server errors
- Confirmed database entries for linked client users with correct roles

## Result

Linked properties before linking
<img width="1480" height="1004" alt="Screenshot 2025-11-13 at 11 27 42 PM" src="https://github.com/user-attachments/assets/cafecea1-e4b3-4e1c-8f98-1fe0d41cbc67" />

Api documentation of link property to client users endpoint
<img width="1494" height="1004" alt="Screenshot 2025-11-13 at 11 27 07 PM" src="https://github.com/user-attachments/assets/73678f45-98aa-4289-b8c9-4fe2f048e497" />

Property linked to client users
<img width="1500" height="1007" alt="Screenshot 2025-11-13 at 11 28 26 PM" src="https://github.com/user-attachments/assets/1df053c6-2b50-40f4-80af-0c9e7f4311ba" />

Linked properties after linking action
<img width="1481" height="1003" alt="Screenshot 2025-11-13 at 11 35 21 PM" src="https://github.com/user-attachments/assets/2c8757f5-375e-4b71-8caf-d7b9a295fb49" />


## Related Work

N/A

## Documentation

OpenAPI docs updated (docs.go, swagger.json, swagger.yaml) to include the new endpoint and request schema.