### PR TITLE
Add an endpoint to unlink properties from client users

### DIFF
--- a/services/main/docs/docs.go
+++ b/services/main/docs/docs.go
@@ -2413,6 +2413,61 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/api/v1/properties/{property_id}/client-users:unlink": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Unlink property from client users",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClientUserProperties"
+                ],
+                "summary": "Unlink property from client users",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Property ID",
+                        "name": "property_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Unlink Property From Client Users Request Body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.UnlinkPropertyFromClientUsersRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Property unlinked from client users successfully"
+                    },
+                    "422": {
+                        "description": "Validation error occured",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "An unexpected error occurred",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -2837,6 +2892,24 @@ const docTemplate = `{
             ],
             "properties": {
                 "property_ids": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "a8098c1a-f86e-11da-bd1a-00112444be1e"
+                    ]
+                }
+            }
+        },
+        "handlers.UnlinkPropertyFromClientUsersRequest": {
+            "type": "object",
+            "required": [
+                "client_user_ids"
+            ],
+            "properties": {
+                "client_user_ids": {
                     "type": "array",
                     "minItems": 1,
                     "items": {

--- a/services/main/docs/swagger.json
+++ b/services/main/docs/swagger.json
@@ -2405,6 +2405,61 @@
                     }
                 }
             }
+        },
+        "/api/v1/properties/{property_id}/client-users:unlink": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Unlink property from client users",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClientUserProperties"
+                ],
+                "summary": "Unlink property from client users",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Property ID",
+                        "name": "property_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Unlink Property From Client Users Request Body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.UnlinkPropertyFromClientUsersRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Property unlinked from client users successfully"
+                    },
+                    "422": {
+                        "description": "Validation error occured",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "An unexpected error occurred",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -2829,6 +2884,24 @@
             ],
             "properties": {
                 "property_ids": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "a8098c1a-f86e-11da-bd1a-00112444be1e"
+                    ]
+                }
+            }
+        },
+        "handlers.UnlinkPropertyFromClientUsersRequest": {
+            "type": "object",
+            "required": [
+                "client_user_ids"
+            ],
+            "properties": {
+                "client_user_ids": {
                     "type": "array",
                     "minItems": 1,
                     "items": {

--- a/services/main/docs/swagger.yaml
+++ b/services/main/docs/swagger.yaml
@@ -314,6 +314,18 @@ definitions:
     required:
     - property_ids
     type: object
+  handlers.UnlinkPropertyFromClientUsersRequest:
+    properties:
+      client_user_ids:
+        example:
+        - a8098c1a-f86e-11da-bd1a-00112444be1e
+        items:
+          type: string
+        minItems: 1
+        type: array
+    required:
+    - client_user_ids
+    type: object
   handlers.UpdateDocumentRequest:
     properties:
       content:
@@ -2187,6 +2199,41 @@ paths:
       security:
       - BearerAuth: []
       summary: Link property to client users
+      tags:
+      - ClientUserProperties
+  /api/v1/properties/{property_id}/client-users:unlink:
+    delete:
+      consumes:
+      - application/json
+      description: Unlink property from client users
+      parameters:
+      - description: Property ID
+        in: path
+        name: property_id
+        required: true
+        type: string
+      - description: Unlink Property From Client Users Request Body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.UnlinkPropertyFromClientUsersRequest'
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: Property unlinked from client users successfully
+        "422":
+          description: Validation error occured
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "500":
+          description: An unexpected error occurred
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Unlink property from client users
       tags:
       - ClientUserProperties
   /api/v1/properties/me:

--- a/services/main/internal/repository/client-user-property.go
+++ b/services/main/internal/repository/client-user-property.go
@@ -21,6 +21,7 @@ type ClientUserPropertyRepository interface {
 		filterQuery ListClientUserPropertiesFilter,
 	) (int64, error)
 	BulkCreate(ctx context.Context, clientUserProperty *[]models.ClientUserProperty) error
+	UnlinkPropertyFromClientUsers(context context.Context, input UnlinkPropertyFromClientUsersQuery) error
 }
 
 type clientUserPropertyRepository struct {
@@ -74,6 +75,25 @@ func (r *clientUserPropertyRepository) DeleteByClientUserID(
 	query := db.WithContext(ctx).
 		Where("client_user_id = ?", input.ClientUserID).
 		Where("property_id IN (?)", input.PropertyIDs)
+
+	result := query.Delete(&models.ClientUserProperty{}).Error
+	return result
+}
+
+type UnlinkPropertyFromClientUsersQuery struct {
+	PropertyID    string
+	ClientUserIDs []string
+}
+
+func (r *clientUserPropertyRepository) UnlinkPropertyFromClientUsers(
+	ctx context.Context,
+	input UnlinkPropertyFromClientUsersQuery,
+) error {
+	db := lib.ResolveDB(ctx, r.DB)
+
+	query := db.WithContext(ctx).
+		Where("property_id = ?", input.PropertyID).
+		Where("client_user_id IN (?)", input.ClientUserIDs)
 
 	result := query.Delete(&models.ClientUserProperty{}).Error
 	return result

--- a/services/main/internal/router/client-user.go
+++ b/services/main/internal/router/client-user.go
@@ -63,6 +63,8 @@ func NewClientUserRouter(appCtx pkg.AppContext, handlers handlers.Handlers) func
 						Delete("/", handlers.PropertyHandler.DeleteProperty)
 					r.With(middlewares.ValidateRoleClientUserMiddleware(appCtx, "ADMIN", "OWNER")).
 						Post("/client-users:link", handlers.ClientUserPropertyHandler.LinkPropertyToClientUsers)
+					r.With(middlewares.ValidateRoleClientUserMiddleware(appCtx, "ADMIN", "OWNER")).
+						Delete("/client-users:unlink", handlers.ClientUserPropertyHandler.UnlinkPropertyFromClientUsers)
 				})
 			})
 

--- a/services/main/internal/services/client-user-property.go
+++ b/services/main/internal/services/client-user-property.go
@@ -25,6 +25,7 @@ type ClientUserPropertyService interface {
 	LinkClientUserToProperties(context context.Context, input LinkClientUserToPropertiesInput) error
 	UnlinkByClientUserID(context context.Context, input repository.UnlinkClientUserFromPropertyQuery) error
 	LinkPropertyToClientUsers(context context.Context, input LinkPropertyToClientUsersInput) error
+	UnlinkPropertyFromClientUsers(context context.Context, input repository.UnlinkPropertyFromClientUsersQuery) error
 }
 
 type clientUserPropertyService struct {
@@ -106,6 +107,24 @@ func (s *clientUserPropertyService) LinkPropertyToClientUsers(
 			Metadata: map[string]string{
 				"function": "LinkPropertyToClientUsers",
 				"action":   "creating property client users link",
+			},
+		})
+	}
+
+	return nil
+}
+
+func (s *clientUserPropertyService) UnlinkPropertyFromClientUsers(
+	ctx context.Context,
+	input repository.UnlinkPropertyFromClientUsersQuery,
+) error {
+	unlinkErr := s.repo.UnlinkPropertyFromClientUsers(ctx, input)
+	if unlinkErr != nil {
+		return pkg.InternalServerError(unlinkErr.Error(), &pkg.RentLoopErrorParams{
+			Err: unlinkErr,
+			Metadata: map[string]string{
+				"function": "UnlinkPropertyFromClientUsers",
+				"action":   "deleting client user property links",
 			},
 		})
 	}


### PR DESCRIPTION
## PR Name or Description

Add an endpoint to unlink properties from client users

## Overview

This pull request introduces a new API endpoint to allow unlinking properties from multiple client users. It includes handler, service, repository, and documentation updates to support the feature.

## Detailed Technical Change

- Added `UnlinkPropertyFromClientUsersRequest` struct and handler in `internal/handlers/client-user-property.go`.
- Implemented `UnlinkPropertyFromClientUsers` method in service (`internal/services/client-user-property.go`) and repository (`internal/repository/client-user-property.go`).
- Updated `ClientUserPropertyRepository` and `ClientUserPropertyService` interfaces.
- Registered the new route in `internal/router/client-user.go`.
- Updated API documentation in `docs.go`, `swagger.json`, and `swagger.yaml` to describe the new endpoint and request schema.

## Testing Approach

- Manual testing to ensure properties are unlinked from specified client users.
- Verified correct HTTP status codes (204, 422, 500) and error handling.
- Confirmed database changes for property-client user links.

## Result

The properties of a user before unlinking
<img width="1501" height="1003" alt="Screenshot 2025-11-14 at 9 46 06 PM" src="https://github.com/user-attachments/assets/3f49e612-628d-4673-81ca-6b5b474ece2a" />

Unlinking request body
<img width="1500" height="1004" alt="Screenshot 2025-11-14 at 9 46 42 PM" src="https://github.com/user-attachments/assets/7fc9f76a-847c-4457-b06b-fe38c8a14065" />

Unlinked property from client users in array
<img width="1511" height="1004" alt="Screenshot 2025-11-14 at 9 46 58 PM" src="https://github.com/user-attachments/assets/45e3f5bc-01b5-45ce-8a70-5847eb2954ae" />

The properties of a user after unlinking
<img width="1489" height="1004" alt="Screenshot 2025-11-14 at 9 47 12 PM" src="https://github.com/user-attachments/assets/66b9db83-2a2a-4cf9-82bf-5c7995f98ae9" />

## Related Work

N/A

## Documentation

API documentation updated in `docs.go`, `swagger.json`, and `swagger.yaml` to reflect the new endpoint and request schema.