### PR TITLE
Add not_in_property_id filter to ListClientUsers API

### DIFF
--- a/services/main/docs/docs.go
+++ b/services/main/docs/docs.go
@@ -964,6 +964,12 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "type": "string",
+                        "example": "e4ad26d4-d7e9-4599-a246-5e88abba6083",
+                        "name": "not_in_property_id",
+                        "in": "query"
+                    },
+                    {
                         "enum": [
                             "asc",
                             "desc"

--- a/services/main/docs/swagger.json
+++ b/services/main/docs/swagger.json
@@ -956,6 +956,12 @@
                         "in": "query"
                     },
                     {
+                        "type": "string",
+                        "example": "e4ad26d4-d7e9-4599-a246-5e88abba6083",
+                        "name": "not_in_property_id",
+                        "in": "query"
+                    },
+                    {
                         "enum": [
                             "asc",
                             "desc"

--- a/services/main/docs/swagger.yaml
+++ b/services/main/docs/swagger.yaml
@@ -1424,6 +1424,10 @@ paths:
       - in: query
         name: end_date
         type: string
+      - example: e4ad26d4-d7e9-4599-a246-5e88abba6083
+        in: query
+        name: not_in_property_id
+        type: string
       - enum:
         - asc
         - desc

--- a/services/main/internal/handlers/client-user.go
+++ b/services/main/internal/handlers/client-user.go
@@ -257,8 +257,9 @@ func (h *ClientUserHandler) ResetClientUserPassword(w http.ResponseWriter, r *ht
 
 type ListClientUsersFilterRequest struct {
 	lib.FilterQueryInput
-	Status string `json:"status" validate:"oneof=ClientUser.Status.Active ClientUser.Status.Inactive" example:"ClientUser.Status.Active"`
-	Role   string `json:"role"   validate:"oneof=OWNER ADMIN STAFF"                                   example:"OWNER"`
+	Status          string `json:"status"             validate:"oneof=ClientUser.Status.Active ClientUser.Status.Inactive" example:"ClientUser.Status.Active"`
+	Role            string `json:"role"               validate:"oneof=OWNER ADMIN STAFF"                                   example:"OWNER"`
+	NotInPropertyID string `json:"not_in_property_id" validate:"uuid"                                                      example:"e4ad26d4-d7e9-4599-a246-5e88abba6083"`
 }
 
 // ListClientUsers godoc
@@ -294,10 +295,11 @@ func (h *ClientUserHandler) ListClientUsers(w http.ResponseWriter, r *http.Reque
 	}
 
 	input := repository.ListClientUsersFilter{
-		FilterQuery: *filterQuery,
-		ClientID:    currentClientUser.ClientID,
-		Status:      lib.NullOrString(r.URL.Query().Get("status")),
-		Role:        lib.NullOrString(r.URL.Query().Get("role")),
+		FilterQuery:     *filterQuery,
+		ClientID:        currentClientUser.ClientID,
+		Status:          lib.NullOrString(r.URL.Query().Get("status")),
+		Role:            lib.NullOrString(r.URL.Query().Get("role")),
+		NotInPropertyID: lib.NullOrString(r.URL.Query().Get("not_in_property_id")),
 	}
 
 	clientUsers, clientUsersErr := h.service.ListClientUsers(r.Context(), input)


### PR DESCRIPTION
## PR Name or Description

Add not_in_property_id filter to ListClientUsers API

## Overview

This pull request introduces a new query parameter, not_in_property_id, to the ListClientUsers endpoint, allowing users to exclude client users associated with a specific property.

## Detailed Technical Change

- Updated OpenAPI documentation files (docs.go, swagger.json, swagger.yaml) to include the not_in_property_id query parameter.
- Modified ListClientUsersFilterRequest struct in internal/handlers/client-user.go to add NotInPropertyID.
- Updated handler logic to parse and pass not_in_property_id to the repository.
- Extended ListClientUsersFilter struct in internal/repository/client-user.go to include NotInPropertyID.
- Added notInPropertyScope function to filter out client users associated with the given property ID in repository queries.

## Testing Approach

- Manual testing: Queried the ListClientUsers endpoint with and without the not_in_property_id parameter to verify correct exclusion of users.
- Verified that the API returns expected results and no errors.
- Confirmed that documentation updates are reflected in Swagger UI.

## Result

A client user not associated with any property
<img width="1458" height="1004" alt="Screenshot 2025-11-21 at 9 26 14 PM" src="https://github.com/user-attachments/assets/c618452e-6c63-40ee-b88b-2533f44c27d9" />

Appears in a list of client users not attached to a specific property
<img width="1454" height="1004" alt="Screenshot 2025-11-21 at 9 27 16 PM" src="https://github.com/user-attachments/assets/0083e0c4-d7db-477c-ab9c-b16660273982" />

## Related Work

N/A

## Documentation

OpenAPI documentation updated (docs.go, swagger.json, swagger.yaml) to reflect the new query parameter.