### PR TITLE
Add API endpoint for client user password update

### DIFF
--- a/services/main/docs/docs.go
+++ b/services/main/docs/docs.go
@@ -1376,6 +1376,80 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/client-users/me/password": {
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update client user password",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClientUsers"
+                ],
+                "summary": "Update client user password",
+                "parameters": [
+                    {
+                        "description": "Update Client User Password Request Body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.UpdateClientUserPasswordRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "$ref": "#/definitions/transformations.OutputClientUser"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Error occurred when updating client user password",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid or absent authentication token",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Client user not found",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error occured",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "An unexpected error occurred",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/client-users/reset-password": {
             "post": {
                 "security": [
@@ -3388,6 +3462,25 @@ const docTemplate = `{
                     "example": [
                         "a8098c1a-f86e-11da-bd1a-00112444be1e"
                     ]
+                }
+            }
+        },
+        "handlers.UpdateClientUserPasswordRequest": {
+            "type": "object",
+            "required": [
+                "new_password",
+                "old_password"
+            ],
+            "properties": {
+                "new_password": {
+                    "type": "string",
+                    "minLength": 6,
+                    "example": "newpassword123"
+                },
+                "old_password": {
+                    "type": "string",
+                    "minLength": 6,
+                    "example": "oldpassword123"
                 }
             }
         },

--- a/services/main/docs/swagger.json
+++ b/services/main/docs/swagger.json
@@ -1368,6 +1368,80 @@
                 }
             }
         },
+        "/api/v1/client-users/me/password": {
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update client user password",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClientUsers"
+                ],
+                "summary": "Update client user password",
+                "parameters": [
+                    {
+                        "description": "Update Client User Password Request Body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.UpdateClientUserPasswordRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "$ref": "#/definitions/transformations.OutputClientUser"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Error occurred when updating client user password",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid or absent authentication token",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Client user not found",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error occured",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "An unexpected error occurred",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/client-users/reset-password": {
             "post": {
                 "security": [
@@ -3380,6 +3454,25 @@
                     "example": [
                         "a8098c1a-f86e-11da-bd1a-00112444be1e"
                     ]
+                }
+            }
+        },
+        "handlers.UpdateClientUserPasswordRequest": {
+            "type": "object",
+            "required": [
+                "new_password",
+                "old_password"
+            ],
+            "properties": {
+                "new_password": {
+                    "type": "string",
+                    "minLength": 6,
+                    "example": "newpassword123"
+                },
+                "old_password": {
+                    "type": "string",
+                    "minLength": 6,
+                    "example": "oldpassword123"
                 }
             }
         },

--- a/services/main/docs/swagger.yaml
+++ b/services/main/docs/swagger.yaml
@@ -335,6 +335,20 @@ definitions:
     required:
     - client_user_ids
     type: object
+  handlers.UpdateClientUserPasswordRequest:
+    properties:
+      new_password:
+        example: newpassword123
+        minLength: 6
+        type: string
+      old_password:
+        example: oldpassword123
+        minLength: 6
+        type: string
+    required:
+    - new_password
+    - old_password
+    type: object
   handlers.UpdateClientUserRequest:
     properties:
       name:
@@ -1911,6 +1925,53 @@ paths:
       security:
       - BearerAuth: []
       summary: update client user
+      tags:
+      - ClientUsers
+  /api/v1/client-users/me/password:
+    patch:
+      consumes:
+      - application/json
+      description: Update client user password
+      parameters:
+      - description: Update Client User Password Request Body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.UpdateClientUserPasswordRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            properties:
+              data:
+                $ref: '#/definitions/transformations.OutputClientUser'
+            type: object
+        "400":
+          description: Error occurred when updating client user password
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "401":
+          description: Invalid or absent authentication token
+          schema:
+            type: string
+        "404":
+          description: Client user not found
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "422":
+          description: Validation error occured
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "500":
+          description: An unexpected error occurred
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Update client user password
       tags:
       - ClientUsers
   /api/v1/client-users/reset-password:

--- a/services/main/internal/lib/email-templates.go
+++ b/services/main/internal/lib/email-templates.go
@@ -131,3 +131,17 @@ Best regards,
 The rentloop Team
 `
 )
+
+const (
+	CLIENT_USER_PASSWORD_UPDATED_SUBJECT = "Your Rentloop Password Updated"
+	CLIENT_USER_PASSWORD_UPDATED_BODY    = `
+Hey {{name}},
+
+Your password has been changed successfully. if you didn't change this, reach out to support.
+
+{{SUPPORT_DETAILS_TEMPLATE}}
+
+Best regards,
+The rentloop Team
+`
+)

--- a/services/main/internal/router/client-user.go
+++ b/services/main/internal/router/client-user.go
@@ -28,13 +28,16 @@ func NewClientUserRouter(appCtx pkg.AppContext, handlers handlers.Handlers) func
 			// client users
 			r.With(middlewares.ValidateRoleClientUserMiddleware(appCtx, "ADMIN", "OWNER")).
 				Post("/v1/client-users", handlers.ClientUserHandler.CreateClientUser)
-			r.Get("/v1/client-users/me", handlers.ClientUserHandler.GetMe)
 			r.Post(
 				"/v1/client-users/reset-password",
 				handlers.ClientUserHandler.ResetClientUserPassword,
 			)
 			r.Get("/v1/client-users", handlers.ClientUserHandler.ListClientUsers)
-			r.Patch("/v1/client-users/me", handlers.ClientUserHandler.UpdateClientUserSelf)
+			r.Route("/v1/client-users/me", func(r chi.Router) {
+				r.Get("/", handlers.ClientUserHandler.GetMe)
+				r.Patch("/", handlers.ClientUserHandler.UpdateClientUserSelf)
+				r.Patch("/password", handlers.ClientUserHandler.UpdateClientUserPassword)
+			})
 
 			r.Route("/v1/client-users/{client_user_id}", func(r chi.Router) {
 				r.Get("/", handlers.ClientUserHandler.GetClientUserWithPopulate)


### PR DESCRIPTION
## PR Name or Description

Add API endpoint for client user password update

## Overview

This PR introduces a new PATCH endpoint `/api/v1/client-users/me/password` that allows authenticated client users to update their password. It includes request validation, password hashing, and notification via email and SMS.

## Detailed Technical Change

- Added `UpdateClientUserPasswordRequest` struct and handler in `internal/handlers/client-user.go`.
- Implemented `UpateClientUserPassword` service method in `internal/services/client-user.go`.
- Updated router in `internal/router/client-user.go` to include the new endpoint.
- Added email/SMS templates for password update notification in `internal/lib/email-templates.go`.
- Updated OpenAPI documentation in `docs.go`, `swagger.json`, and `swagger.yaml` to document the new endpoint and request schema.

## Testing Approach

- Manual testing via API client (e.g., Postman) to ensure:
  - Endpoint requires authentication.
  - Password is updated only if old password matches and new password is not repeated.
  - Email and SMS notifications are sent.
  - Proper error responses for invalid input, unauthorized access, and edge cases.

## Result
Updating the password of a user
<img width="1469" height="959" alt="Screenshot 2025-11-28 at 4 00 06 PM" src="https://github.com/user-attachments/assets/d085831a-7551-43ac-8045-38a7accaef0c" />

Logging in with the new password of the user
<img width="1451" height="960" alt="Screenshot 2025-11-28 at 4 00 32 PM" src="https://github.com/user-attachments/assets/2657ac5e-a7ca-4685-8da0-2c2f584aaaa2" />

## Related Work

N/A

## Documentation

- OpenAPI docs updated (`docs.go`, `swagger.json`, `swagger.yaml`) to reflect the new endpoint and request schema.
