### PR TITLE
Add List Property Blocks API Endpoint

### DIFF
--- a/services/main/docs/docs.go
+++ b/services/main/docs/docs.go
@@ -2891,6 +2891,146 @@ const docTemplate = `{
             }
         },
         "/api/v1/properties/{property_id}/blocks": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List property blocks",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "PropertyBlocks"
+                ],
+                "summary": "List property blocks",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Property ID",
+                        "name": "property_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "name": "end_date",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "asc",
+                            "desc"
+                        ],
+                        "type": "string",
+                        "name": "order",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "order_by",
+                        "in": "query"
+                    },
+                    {
+                        "minimum": 0,
+                        "type": "integer",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "minimum": 0,
+                        "type": "integer",
+                        "name": "page_size",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "name": "populate",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "query",
+                        "in": "query"
+                    },
+                    {
+                        "minItems": 1,
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "name": "search_fields",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "start_date",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "PropertyBlock.Status.Active",
+                            "PropertyBlock.Status.Inactive",
+                            "PropertyBlock.Status.Maintenance"
+                        ],
+                        "type": "string",
+                        "example": "PropertyBlock.Status.Active",
+                        "name": "status",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "type": "object",
+                                    "properties": {
+                                        "meta": {
+                                            "$ref": "#/definitions/lib.HTTPReturnPaginatedMetaResponse"
+                                        },
+                                        "rows": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/transformations.OutputPropertyBlock"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
             "post": {
                 "security": [
                     {

--- a/services/main/docs/swagger.json
+++ b/services/main/docs/swagger.json
@@ -2883,6 +2883,146 @@
             }
         },
         "/api/v1/properties/{property_id}/blocks": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List property blocks",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "PropertyBlocks"
+                ],
+                "summary": "List property blocks",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Property ID",
+                        "name": "property_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "name": "end_date",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "asc",
+                            "desc"
+                        ],
+                        "type": "string",
+                        "name": "order",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "order_by",
+                        "in": "query"
+                    },
+                    {
+                        "minimum": 0,
+                        "type": "integer",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "minimum": 0,
+                        "type": "integer",
+                        "name": "page_size",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "name": "populate",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "query",
+                        "in": "query"
+                    },
+                    {
+                        "minItems": 1,
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "name": "search_fields",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "start_date",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "PropertyBlock.Status.Active",
+                            "PropertyBlock.Status.Inactive",
+                            "PropertyBlock.Status.Maintenance"
+                        ],
+                        "type": "string",
+                        "example": "PropertyBlock.Status.Active",
+                        "name": "status",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "type": "object",
+                                    "properties": {
+                                        "meta": {
+                                            "$ref": "#/definitions/lib.HTTPReturnPaginatedMetaResponse"
+                                        },
+                                        "rows": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/transformations.OutputPropertyBlock"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
             "post": {
                 "security": [
                     {

--- a/services/main/docs/swagger.yaml
+++ b/services/main/docs/swagger.yaml
@@ -2619,6 +2619,97 @@ paths:
       tags:
       - Properties
   /api/v1/properties/{property_id}/blocks:
+    get:
+      consumes:
+      - application/json
+      description: List property blocks
+      parameters:
+      - description: Property ID
+        in: path
+        name: property_id
+        required: true
+        type: string
+      - in: query
+        name: end_date
+        type: string
+      - enum:
+        - asc
+        - desc
+        in: query
+        name: order
+        type: string
+      - in: query
+        name: order_by
+        type: string
+      - in: query
+        minimum: 0
+        name: page
+        type: integer
+      - in: query
+        minimum: 0
+        name: page_size
+        type: integer
+      - collectionFormat: csv
+        in: query
+        items:
+          type: string
+        name: populate
+        type: array
+      - in: query
+        name: query
+        type: string
+      - collectionFormat: csv
+        in: query
+        items:
+          type: string
+        minItems: 1
+        name: search_fields
+        type: array
+      - in: query
+        name: start_date
+        type: string
+      - enum:
+        - PropertyBlock.Status.Active
+        - PropertyBlock.Status.Inactive
+        - PropertyBlock.Status.Maintenance
+        example: PropertyBlock.Status.Active
+        in: query
+        name: status
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            properties:
+              data:
+                properties:
+                  meta:
+                    $ref: '#/definitions/lib.HTTPReturnPaginatedMetaResponse'
+                  rows:
+                    items:
+                      $ref: '#/definitions/transformations.OutputPropertyBlock'
+                    type: array
+                type: object
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "401":
+          description: Unauthorized
+          schema:
+            type: string
+        "500":
+          description: Internal Server Error
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: List property blocks
+      tags:
+      - PropertyBlocks
     post:
       consumes:
       - application/json

--- a/services/main/internal/repository/property-block.go
+++ b/services/main/internal/repository/property-block.go
@@ -10,6 +10,8 @@ import (
 
 type PropertyBlockRepository interface {
 	Create(context context.Context, propertyBlock *models.PropertyBlock) error
+	List(context context.Context, filterQuery ListPropertyBlocksFilter) (*[]models.PropertyBlock, error)
+	Count(context context.Context, filterQuery ListPropertyBlocksFilter) (int64, error)
 }
 
 type propertyBlockRepository struct {
@@ -24,4 +26,72 @@ func (r *propertyBlockRepository) Create(ctx context.Context, propertyBlock *mod
 	db := lib.ResolveDB(ctx, r.DB)
 
 	return db.Create(propertyBlock).Error
+}
+
+type ListPropertyBlocksFilter struct {
+	lib.FilterQuery
+	PropertyID string
+	Status     *string
+}
+
+func (r *propertyBlockRepository) List(
+	ctx context.Context,
+	filterQuery ListPropertyBlocksFilter,
+) (*[]models.PropertyBlock, error) {
+	var propertyBlocks []models.PropertyBlock
+
+	db := r.DB.WithContext(ctx).Scopes(
+		propertyBlockPropertyIDScope(filterQuery.PropertyID),
+		propertyBlockStatusScope(filterQuery.Status),
+		DateRangeScope("property_blocks", filterQuery.DateRange),
+		SearchScope("property_blocks", filterQuery.Search),
+
+		PaginationScope(filterQuery.Page, filterQuery.PageSize),
+		OrderScope("property_blocks", filterQuery.OrderBy, filterQuery.Order),
+	)
+
+	if filterQuery.Populate != nil {
+		for _, field := range *filterQuery.Populate {
+			db = db.Preload(field)
+		}
+	}
+	results := db.Find(&propertyBlocks)
+
+	if results.Error != nil {
+		return nil, results.Error
+	}
+	return &propertyBlocks, nil
+}
+
+func (r *propertyBlockRepository) Count(ctx context.Context, filterQuery ListPropertyBlocksFilter) (int64, error) {
+	var count int64
+
+	result := r.DB.WithContext(ctx).
+		Model(&models.PropertyBlock{}).
+		Scopes(
+			propertyBlockPropertyIDScope(filterQuery.PropertyID),
+			propertyBlockStatusScope(filterQuery.Status),
+			DateRangeScope("property_blocks", filterQuery.DateRange),
+			SearchScope("property_blocks", filterQuery.Search),
+		).Count(&count)
+
+	if result.Error != nil {
+		return 0, result.Error
+	}
+	return count, nil
+}
+
+func propertyBlockPropertyIDScope(propertyID string) func(db *gorm.DB) *gorm.DB {
+	return func(db *gorm.DB) *gorm.DB {
+		return db.Where("property_blocks.property_id = ?", propertyID)
+	}
+}
+
+func propertyBlockStatusScope(propertyBlockStatus *string) func(db *gorm.DB) *gorm.DB {
+	return func(db *gorm.DB) *gorm.DB {
+		if propertyBlockStatus == nil {
+			return db
+		}
+		return db.Where("property_blocks.status = ?", *propertyBlockStatus)
+	}
 }

--- a/services/main/internal/router/client-user.go
+++ b/services/main/internal/router/client-user.go
@@ -74,8 +74,11 @@ func NewClientUserRouter(appCtx pkg.AppContext, handlers handlers.Handlers) func
 					r.With(middlewares.ValidateRoleClientUserMiddleware(appCtx, "ADMIN", "OWNER")).
 						Delete("/client-users:unlink", handlers.ClientUserPropertyHandler.UnlinkPropertyFromClientUsers)
 
-					r.With(middlewares.ValidateRoleClientUserPropertyMiddleware(appCtx, "MANAGER")).
-						Post("/blocks", handlers.PropertyBlockHandler.CreatePropertyBlock)
+					r.Route("/blocks", func(r chi.Router) {
+						r.With(middlewares.ValidateRoleClientUserPropertyMiddleware(appCtx, "MANAGER")).
+							Post("/", handlers.PropertyBlockHandler.CreatePropertyBlock)
+						r.Get("/", handlers.PropertyBlockHandler.ListPropertyBlocks)
+					})
 				})
 			})
 

--- a/services/main/internal/services/property-block.go
+++ b/services/main/internal/services/property-block.go
@@ -11,6 +11,11 @@ import (
 
 type PropertyBlockService interface {
 	CreatePropertyBlock(context context.Context, input CreatePropertyBlockInput) (*models.PropertyBlock, error)
+	ListPropertyBlocks(
+		context context.Context,
+		filterQuery repository.ListPropertyBlocksFilter,
+	) ([]models.PropertyBlock, error)
+	CountPropertyBlocks(context context.Context, filterQuery repository.ListPropertyBlocksFilter) (int64, error)
 }
 
 type propertyBlockService struct {
@@ -61,4 +66,40 @@ func (s *propertyBlockService) CreatePropertyBlock(
 		})
 	}
 	return &propertyBlock, nil
+}
+
+func (s *propertyBlockService) ListPropertyBlocks(
+	ctx context.Context,
+	filterQuery repository.ListPropertyBlocksFilter,
+) ([]models.PropertyBlock, error) {
+	propertyBlocks, listPropertyBlocksErr := s.repo.List(ctx, filterQuery)
+	if listPropertyBlocksErr != nil {
+		return nil, pkg.InternalServerError(listPropertyBlocksErr.Error(), &pkg.RentLoopErrorParams{
+			Err: listPropertyBlocksErr,
+			Metadata: map[string]string{
+				"function": "ListPropertyBlocks",
+				"action":   "listing property blocks",
+			},
+		})
+	}
+
+	return *propertyBlocks, nil
+}
+
+func (s *propertyBlockService) CountPropertyBlocks(
+	ctx context.Context,
+	filterQuery repository.ListPropertyBlocksFilter,
+) (int64, error) {
+	propertyBlocksCount, countPropertyBlocksErr := s.repo.Count(ctx, filterQuery)
+	if countPropertyBlocksErr != nil {
+		return 0, pkg.InternalServerError(countPropertyBlocksErr.Error(), &pkg.RentLoopErrorParams{
+			Err: countPropertyBlocksErr,
+			Metadata: map[string]string{
+				"function": "CountPropertyBlocks",
+				"action":   "counting property blocks",
+			},
+		})
+	}
+
+	return propertyBlocksCount, nil
 }


### PR DESCRIPTION
## PR Name or Description

Add List Property Blocks API Endpoint

## Overview

This pull request introduces a new API endpoint to list property blocks for a given property, including filtering, pagination, and status-based querying.

## Detailed Technical Change

- Added `PropertyBlockHandler.ListPropertyBlocks` and `PropertyBlockListQueryFilter` in `internal/handlers/property-block.go`.
- Implemented repository methods `List` and `Count` for `property blocks` in `internal/repository/property-block.go`.
- Extended `PropertyBlockService` with `ListPropertyBlocks` and `CountPropertyBlocks` in `internal/services/property-block.go`.
- Updated client-user router to support `GET /api/v1/properties/{property_id}/blocks` in `internal/router/client-user.go`.
- Updated API documentation in `docs.go`, `swagger.json`, and `swagger.yaml` to document the new endpoint, parameters, and responses.

## Testing Approach

- Manually tested the new endpoint with various query parameters (status, pagination, search, etc.).
- Verified correct filtering, pagination, and response structure.
- Confirmed endpoint is protected by authentication and role-based access.

## Result
<img width="1461" height="959" alt="Screenshot 2025-12-06 at 12 41 58 PM" src="https://github.com/user-attachments/assets/5918ba05-32ad-45c4-a2f5-00e9b0748213" />

## Related Work

N/A

## Documentation

API documentation updated in Swagger files (`docs.go`, `swagger.json`, `swagger.yaml`) to reflect the new endpoint and its parameters.