### PR TITLE
Add a GET endpoint to retrieve the property block by ID

### DIFF
--- a/services/main/docs/docs.go
+++ b/services/main/docs/docs.go
@@ -3111,6 +3111,88 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/properties/{property_id}/blocks/{block_id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get property block by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "PropertyBlocks"
+                ],
+                "summary": "Get property block by ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Property ID",
+                        "name": "property_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Property block ID",
+                        "name": "block_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "name": "populate",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Property block retrieved successfully",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "$ref": "#/definitions/transformations.OutputPropertyBlock"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Error occurred when fetching a property block",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid or absent authentication token",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Property block not found",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "An unexpected error occured",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/properties/{property_id}/client-users:link": {
             "post": {
                 "security": [

--- a/services/main/docs/swagger.json
+++ b/services/main/docs/swagger.json
@@ -3103,6 +3103,88 @@
                 }
             }
         },
+        "/api/v1/properties/{property_id}/blocks/{block_id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get property block by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "PropertyBlocks"
+                ],
+                "summary": "Get property block by ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Property ID",
+                        "name": "property_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Property block ID",
+                        "name": "block_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "name": "populate",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Property block retrieved successfully",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "$ref": "#/definitions/transformations.OutputPropertyBlock"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Error occurred when fetching a property block",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid or absent authentication token",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Property block not found",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "An unexpected error occured",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/properties/{property_id}/client-users:link": {
             "post": {
                 "security": [

--- a/services/main/docs/swagger.yaml
+++ b/services/main/docs/swagger.yaml
@@ -2761,6 +2761,59 @@ paths:
       summary: Create a new property block
       tags:
       - PropertyBlocks
+  /api/v1/properties/{property_id}/blocks/{block_id}:
+    get:
+      consumes:
+      - application/json
+      description: Get property block by ID
+      parameters:
+      - description: Property ID
+        in: path
+        name: property_id
+        required: true
+        type: string
+      - description: Property block ID
+        in: path
+        name: block_id
+        required: true
+        type: string
+      - collectionFormat: csv
+        in: query
+        items:
+          type: string
+        name: populate
+        type: array
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Property block retrieved successfully
+          schema:
+            properties:
+              data:
+                $ref: '#/definitions/transformations.OutputPropertyBlock'
+            type: object
+        "400":
+          description: Error occurred when fetching a property block
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "401":
+          description: Invalid or absent authentication token
+          schema:
+            type: string
+        "404":
+          description: Property block not found
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "500":
+          description: An unexpected error occured
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Get property block by ID
+      tags:
+      - PropertyBlocks
   /api/v1/properties/{property_id}/client-users:link:
     post:
       consumes:

--- a/services/main/internal/router/client-user.go
+++ b/services/main/internal/router/client-user.go
@@ -78,6 +78,9 @@ func NewClientUserRouter(appCtx pkg.AppContext, handlers handlers.Handlers) func
 						r.With(middlewares.ValidateRoleClientUserPropertyMiddleware(appCtx, "MANAGER")).
 							Post("/", handlers.PropertyBlockHandler.CreatePropertyBlock)
 						r.Get("/", handlers.PropertyBlockHandler.ListPropertyBlocks)
+						r.Route("/{block_id}", func(r chi.Router) {
+							r.Get("/", handlers.PropertyBlockHandler.GetPropertyBlock)
+						})
 					})
 				})
 			})


### PR DESCRIPTION
## PR Name or Description

Add a GET endpoint to retrieve the property block by ID

## Overview

This pull request introduces a new API endpoint to fetch a property block by its ID within a property. It includes handler, service, repository, and route updates, as well as documentation changes.

## Detailed Technical Change

- Added `GetPropertyBlock` handler in `internal/handlers/property-block.go` with request/response documentation.
- Introduced `GetPropertyBlock` method in `PropertyBlockService` (`internal/services/property-block.go`).
- Implemented `GetByIDWithQuery` in `PropertyBlockRepository` and defined `GetPropertyBlockQuery` struct (`internal/repository/property-block.go`).
- Registered the new route `/api/v1/properties/{property_id}/blocks/{block_id}` in `internal/router/client-user.go`.
- Updated OpenAPI documentation in `docs/swagger.yaml`, `docs/swagger.json`, and `docs/docs.go`.

## Testing Approach

- Manual testing via API client (e.g. Postman) to verify the new GET endpoint returns the correct property block or appropriate error responses.
- Confirmed correct integration with authentication and error handling.
- No automated test changes included in this PR.

## Result
<img width="1479" height="960" alt="Screenshot 2025-12-06 at 6 21 35 PM" src="https://github.com/user-attachments/assets/bad28cbd-7d6c-4612-8960-dcdfb9a3ad50" />


## Related Work

N/A

## Documentation

OpenAPI/Swagger documentation updated to reflect the new endpoint. No additional documentation changes required.