### PR TITLE
Add PATCH endpoint for updating property blocks

### DIFF
--- a/services/main/docs/docs.go
+++ b/services/main/docs/docs.go
@@ -3191,6 +3191,98 @@ const docTemplate = `{
                         }
                     }
                 }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update a property block",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "PropertyBlocks"
+                ],
+                "summary": "Update a property block",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Property ID",
+                        "name": "property_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Property block ID",
+                        "name": "block_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Property block details",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.UpdatePropertyBlockRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Property block updated successfully",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "$ref": "#/definitions/transformations.OutputPropertyBlock"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Error occurred when updating a property block",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid or absent authentication token",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden access",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Property block not found",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "422": {
+                        "description": "Invalid request body",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "An unexpected error occurred",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
             }
         },
         "/api/v1/properties/{property_id}/client-users:link": {
@@ -4056,6 +4148,31 @@ const docTemplate = `{
                 "title": {
                     "type": "string",
                     "example": "Updated Lease Agreement"
+                }
+            }
+        },
+        "handlers.UpdatePropertyBlockRequest": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "example": "Spacious apartment with sea view."
+                },
+                "images": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "https://example.com/image1.jpg",
+                        "https://example.com/image2.jpg"
+                    ]
+                },
+                "name": {
+                    "type": "string",
+                    "maxLength": 100,
+                    "minLength": 2,
+                    "example": "Luxury Apartment"
                 }
             }
         },

--- a/services/main/docs/swagger.json
+++ b/services/main/docs/swagger.json
@@ -3183,6 +3183,98 @@
                         }
                     }
                 }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update a property block",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "PropertyBlocks"
+                ],
+                "summary": "Update a property block",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Property ID",
+                        "name": "property_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Property block ID",
+                        "name": "block_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Property block details",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.UpdatePropertyBlockRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Property block updated successfully",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "$ref": "#/definitions/transformations.OutputPropertyBlock"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Error occurred when updating a property block",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid or absent authentication token",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden access",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Property block not found",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "422": {
+                        "description": "Invalid request body",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "An unexpected error occurred",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
             }
         },
         "/api/v1/properties/{property_id}/client-users:link": {
@@ -4048,6 +4140,31 @@
                 "title": {
                     "type": "string",
                     "example": "Updated Lease Agreement"
+                }
+            }
+        },
+        "handlers.UpdatePropertyBlockRequest": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "example": "Spacious apartment with sea view."
+                },
+                "images": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "https://example.com/image1.jpg",
+                        "https://example.com/image2.jpg"
+                    ]
+                },
+                "name": {
+                    "type": "string",
+                    "maxLength": 100,
+                    "minLength": 2,
+                    "example": "Luxury Apartment"
                 }
             }
         },

--- a/services/main/docs/swagger.yaml
+++ b/services/main/docs/swagger.yaml
@@ -409,6 +409,24 @@ definitions:
         example: Updated Lease Agreement
         type: string
     type: object
+  handlers.UpdatePropertyBlockRequest:
+    properties:
+      description:
+        example: Spacious apartment with sea view.
+        type: string
+      images:
+        example:
+        - https://example.com/image1.jpg
+        - https://example.com/image2.jpg
+        items:
+          type: string
+        type: array
+      name:
+        example: Luxury Apartment
+        maxLength: 100
+        minLength: 2
+        type: string
+    type: object
   handlers.UpdatePropertyRequest:
     properties:
       address:
@@ -2891,6 +2909,66 @@ paths:
       security:
       - BearerAuth: []
       summary: Get property block by ID
+      tags:
+      - PropertyBlocks
+    patch:
+      consumes:
+      - application/json
+      description: Update a property block
+      parameters:
+      - description: Property ID
+        in: path
+        name: property_id
+        required: true
+        type: string
+      - description: Property block ID
+        in: path
+        name: block_id
+        required: true
+        type: string
+      - description: Property block details
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.UpdatePropertyBlockRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Property block updated successfully
+          schema:
+            properties:
+              data:
+                $ref: '#/definitions/transformations.OutputPropertyBlock'
+            type: object
+        "400":
+          description: Error occurred when updating a property block
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "401":
+          description: Invalid or absent authentication token
+          schema:
+            type: string
+        "403":
+          description: Forbidden access
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "404":
+          description: Property block not found
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "422":
+          description: Invalid request body
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "500":
+          description: An unexpected error occurred
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Update a property block
       tags:
       - PropertyBlocks
   /api/v1/properties/{property_id}/client-users:link:

--- a/services/main/internal/repository/property-block.go
+++ b/services/main/internal/repository/property-block.go
@@ -13,6 +13,7 @@ type PropertyBlockRepository interface {
 	GetByIDWithQuery(context context.Context, query GetPropertyBlockQuery) (*models.PropertyBlock, error)
 	List(context context.Context, filterQuery ListPropertyBlocksFilter) (*[]models.PropertyBlock, error)
 	Count(context context.Context, filterQuery ListPropertyBlocksFilter) (int64, error)
+	Update(context context.Context, propertyBlock *models.PropertyBlock) error
 }
 
 type propertyBlockRepository struct {
@@ -55,6 +56,11 @@ func (r *propertyBlockRepository) GetByIDWithQuery(
 		return nil, result.Error
 	}
 	return &propertyBlock, nil
+}
+
+func (r *propertyBlockRepository) Update(ctx context.Context, propertyBlock *models.PropertyBlock) error {
+	db := lib.ResolveDB(ctx, r.DB)
+	return db.Save(propertyBlock).Error
 }
 
 type ListPropertyBlocksFilter struct {

--- a/services/main/internal/router/client-user.go
+++ b/services/main/internal/router/client-user.go
@@ -80,6 +80,8 @@ func NewClientUserRouter(appCtx pkg.AppContext, handlers handlers.Handlers) func
 						r.Get("/", handlers.PropertyBlockHandler.ListPropertyBlocks)
 						r.Route("/{block_id}", func(r chi.Router) {
 							r.Get("/", handlers.PropertyBlockHandler.GetPropertyBlock)
+							r.With(middlewares.ValidateRoleClientUserPropertyMiddleware(appCtx, "MANAGER")).
+								Patch("/", handlers.PropertyBlockHandler.UpdatePropertyBlock)
 						})
 					})
 


### PR DESCRIPTION
## PR Name or Description

Add PATCH endpoint for updating property blocks

## Overview

This pull request introduces a new PATCH endpoint to update property blocks, including handler, service, repository, and documentation updates.

## Detailed Technical Change

- Added `UpdatePropertyBlockRequest` struct and handler method in `internal/handlers/property-block.go`
- Implemented `UpdatePropertyBlock` service method in `internal/services/property-block.go`
- Added `Update` method to the repository interface and implementation in `internal/repository/property-block.go`
- Registered the PATCH route in `internal/router/client-user.go`
- Updated OpenAPI/Swagger documentation in `docs.go`, `swagger.json`, and `swagger.yaml`

## Testing Approach

- Manual testing via API client (e.g., Postman) to ensure PATCH endpoint updates property blocks as expected
- Verified validation, error handling, and successful update responses

## Result

Before updating a property block
<img width="1443" height="957" alt="Screenshot 2025-12-11 at 2 04 17 PM" src="https://github.com/user-attachments/assets/155b273f-887f-458b-bf2d-53089b893bef" />

Updated a property block
<img width="1447" height="960" alt="Screenshot 2025-12-11 at 2 04 41 PM" src="https://github.com/user-attachments/assets/db2b2158-a71c-4113-a637-f0df3aabe92f" />

After updating a property block
<img width="1454" height="960" alt="Screenshot 2025-12-11 at 2 13 01 PM" src="https://github.com/user-attachments/assets/940d08d5-7f97-453f-9d9a-fa42711a544c" />


## Related Work

N/A

## Documentation

OpenAPI/Swagger documentation updated to reflect the new PATCH endpoint and request schema.
