### PR TITLE
Add Delete Property Block API Endpoint

### DIFF
--- a/services/main/docs/docs.go
+++ b/services/main/docs/docs.go
@@ -3192,6 +3192,75 @@ const docTemplate = `{
                     }
                 }
             },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete a property block",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "PropertyBlocks"
+                ],
+                "summary": "Delete a property block",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Property ID",
+                        "name": "property_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Property block ID",
+                        "name": "block_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Property block deleted successfully"
+                    },
+                    "400": {
+                        "description": "Error occurred when deleting a property block",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid or absent authentication token",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden access",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Property block not found",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "An unexpected error occurred",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
             "patch": {
                 "security": [
                     {

--- a/services/main/docs/swagger.json
+++ b/services/main/docs/swagger.json
@@ -3184,6 +3184,75 @@
                     }
                 }
             },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete a property block",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "PropertyBlocks"
+                ],
+                "summary": "Delete a property block",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Property ID",
+                        "name": "property_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Property block ID",
+                        "name": "block_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Property block deleted successfully"
+                    },
+                    "400": {
+                        "description": "Error occurred when deleting a property block",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid or absent authentication token",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden access",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Property block not found",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "An unexpected error occurred",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
             "patch": {
                 "security": [
                     {

--- a/services/main/docs/swagger.yaml
+++ b/services/main/docs/swagger.yaml
@@ -2859,6 +2859,51 @@ paths:
       tags:
       - PropertyBlocks
   /api/v1/properties/{property_id}/blocks/{block_id}:
+    delete:
+      consumes:
+      - application/json
+      description: Delete a property block
+      parameters:
+      - description: Property ID
+        in: path
+        name: property_id
+        required: true
+        type: string
+      - description: Property block ID
+        in: path
+        name: block_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: Property block deleted successfully
+        "400":
+          description: Error occurred when deleting a property block
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "401":
+          description: Invalid or absent authentication token
+          schema:
+            type: string
+        "403":
+          description: Forbidden access
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "404":
+          description: Property block not found
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "500":
+          description: An unexpected error occurred
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Delete a property block
+      tags:
+      - PropertyBlocks
     get:
       consumes:
       - application/json

--- a/services/main/internal/handlers/property-block.go
+++ b/services/main/internal/handlers/property-block.go
@@ -243,3 +243,38 @@ func (h *PropertyBlockHandler) UpdatePropertyBlock(w http.ResponseWriter, r *htt
 		"data": transformations.DBPropertyBlockToRest(updatedPropertyBlock),
 	})
 }
+
+// DeletePropertyBlock godoc
+//
+//	@Summary		Delete a property block
+//	@Description	Delete a property block
+//	@Tags			PropertyBlocks
+//	@Accept			json
+//	@Security		BearerAuth
+//	@Produce		json
+//	@Param			property_id	path		string			true	"Property ID"
+//	@Param			block_id	path		string			true	"Property block ID"
+//	@Success		204			{object}	nil				"Property block deleted successfully"
+//	@Failure		400			{object}	lib.HTTPError	"Error occurred when deleting a property block"
+//	@Failure		401			{object}	string			"Invalid or absent authentication token"
+//	@Failure		403			{object}	lib.HTTPError	"Forbidden access"
+//	@Failure		404			{object}	lib.HTTPError	"Property block not found"
+//	@Failure		500			{object}	string			"An unexpected error occurred"
+//	@Router			/api/v1/properties/{property_id}/blocks/{block_id} [delete]
+func (h *PropertyBlockHandler) DeletePropertyBlock(w http.ResponseWriter, r *http.Request) {
+	propertyID := chi.URLParam(r, "property_id")
+	propertyBlockID := chi.URLParam(r, "block_id")
+
+	input := repository.DeletePropertyBlockInput{
+		PropertyBlockID: propertyBlockID,
+		PropertyID:      propertyID,
+	}
+
+	deletePropertyBlockErr := h.service.DeletePropertyBlock(r.Context(), input)
+	if deletePropertyBlockErr != nil {
+		HandleErrorResponse(w, deletePropertyBlockErr)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/services/main/internal/repository/property-block.go
+++ b/services/main/internal/repository/property-block.go
@@ -14,6 +14,7 @@ type PropertyBlockRepository interface {
 	List(context context.Context, filterQuery ListPropertyBlocksFilter) (*[]models.PropertyBlock, error)
 	Count(context context.Context, filterQuery ListPropertyBlocksFilter) (int64, error)
 	Update(context context.Context, propertyBlock *models.PropertyBlock) error
+	Delete(context context.Context, input DeletePropertyBlockInput) error
 }
 
 type propertyBlockRepository struct {
@@ -61,6 +62,20 @@ func (r *propertyBlockRepository) GetByIDWithQuery(
 func (r *propertyBlockRepository) Update(ctx context.Context, propertyBlock *models.PropertyBlock) error {
 	db := lib.ResolveDB(ctx, r.DB)
 	return db.Save(propertyBlock).Error
+}
+
+type DeletePropertyBlockInput struct {
+	PropertyBlockID string
+	PropertyID      string
+}
+
+func (r *propertyBlockRepository) Delete(ctx context.Context, input DeletePropertyBlockInput) error {
+	db := lib.ResolveDB(ctx, r.DB)
+
+	return db.WithContext(ctx).
+		Where("id = ? AND property_id = ?", input.PropertyBlockID, input.PropertyID).
+		Delete(&models.PropertyBlock{}).
+		Error
 }
 
 type ListPropertyBlocksFilter struct {

--- a/services/main/internal/router/client-user.go
+++ b/services/main/internal/router/client-user.go
@@ -82,6 +82,8 @@ func NewClientUserRouter(appCtx pkg.AppContext, handlers handlers.Handlers) func
 							r.Get("/", handlers.PropertyBlockHandler.GetPropertyBlock)
 							r.With(middlewares.ValidateRoleClientUserPropertyMiddleware(appCtx, "MANAGER")).
 								Patch("/", handlers.PropertyBlockHandler.UpdatePropertyBlock)
+							r.With(middlewares.ValidateRoleClientUserPropertyMiddleware(appCtx, "MANAGER")).
+								Delete("/", handlers.PropertyBlockHandler.DeletePropertyBlock)
 						})
 					})
 

--- a/services/main/internal/services/property-block.go
+++ b/services/main/internal/services/property-block.go
@@ -20,6 +20,7 @@ type PropertyBlockService interface {
 	) ([]models.PropertyBlock, error)
 	CountPropertyBlocks(context context.Context, filterQuery repository.ListPropertyBlocksFilter) (int64, error)
 	UpdatePropertyBlock(context context.Context, input UpdatePropertyBlockInput) (*models.PropertyBlock, error)
+	DeletePropertyBlock(context context.Context, input repository.DeletePropertyBlockInput) error
 }
 
 type propertyBlockService struct {
@@ -149,6 +150,23 @@ func (s *propertyBlockService) UpdatePropertyBlock(
 	}
 
 	return propertyBlock, nil
+}
+
+func (s *propertyBlockService) DeletePropertyBlock(
+	ctx context.Context,
+	input repository.DeletePropertyBlockInput,
+) error {
+	deletePropertyBlockErr := s.repo.Delete(ctx, input)
+	if deletePropertyBlockErr != nil {
+		return pkg.InternalServerError(deletePropertyBlockErr.Error(), &pkg.RentLoopErrorParams{
+			Err: deletePropertyBlockErr,
+			Metadata: map[string]string{
+				"function": "DeletePropertyBlock",
+				"action":   "deleting property block",
+			},
+		})
+	}
+	return nil
 }
 
 func (s *propertyBlockService) ListPropertyBlocks(


### PR DESCRIPTION
## PR Name or Description

Add Delete Property Block API Endpoint

## Overview

This PR introduces a new API endpoint to delete property blocks. It adds the necessary handler, service, repository method, and updates the OpenAPI documentation to support DELETE requests for property blocks.

## Detailed Technical Change

- Added `DeletePropertyBlock` handler in `internal/handlers/property-block.go`.
- Implemented `Delete` method and `DeletePropertyBlockInput` struct in `internal/repository/property-block.go`.
- Added `DeletePropertyBlock` method to the service interface and implementation in `internal/services/property-block.go`.
- Registered the DELETE route in `internal/router/client-user.go` with appropriate middleware.
- Updated API documentation in `docs/docs.go`, `docs/swagger.json`, and `docs/swagger.yaml` to describe the new endpoint and its responses.

## Testing Approach

- Verified that DELETE requests to `/api/v1/properties/{property_id}/blocks/{block_id}` remove the property block and return HTTP 204.
- Tested error scenarios for invalid IDs, unauthorized access, forbidden access, and not found cases.
- Confirmed middleware enforcement for required roles and authentication.

## Result
Property Block Before deletion
<img width="1447" height="960" alt="Screenshot 2025-12-11 at 2 50 57 PM" src="https://github.com/user-attachments/assets/91527dba-110c-4fff-8dc3-0a0275d60245" />

Property Block Deleted
<img width="1448" height="960" alt="Screenshot 2025-12-11 at 2 51 36 PM" src="https://github.com/user-attachments/assets/e8d43172-748c-4d69-8e0f-ed366208bb98" />

Property Block After deletion
<img width="1444" height="959" alt="Screenshot 2025-12-11 at 2 51 57 PM" src="https://github.com/user-attachments/assets/a8ae871f-1e56-4d52-b0d8-b5b49e8ebfbe" />

## Related Work

N/A

## Documentation

API documentation updated in swagger.yaml, swagger.json, and docs.go.