### PR TITLE
Add "status" field to PropertyBlock update API

### DIFF
--- a/services/main/docs/docs.go
+++ b/services/main/docs/docs.go
@@ -4242,6 +4242,15 @@ const docTemplate = `{
                     "maxLength": 100,
                     "minLength": 2,
                     "example": "Luxury Apartment"
+                },
+                "status": {
+                    "type": "string",
+                    "enum": [
+                        "PropertyBlock.Status.Active",
+                        "PropertyBlock.Status.Maintenance",
+                        "PropertyBlock.Status.Inactive"
+                    ],
+                    "example": "PropertyBlock.Status.Active"
                 }
             }
         },

--- a/services/main/docs/swagger.json
+++ b/services/main/docs/swagger.json
@@ -4234,6 +4234,15 @@
                     "maxLength": 100,
                     "minLength": 2,
                     "example": "Luxury Apartment"
+                },
+                "status": {
+                    "type": "string",
+                    "enum": [
+                        "PropertyBlock.Status.Active",
+                        "PropertyBlock.Status.Maintenance",
+                        "PropertyBlock.Status.Inactive"
+                    ],
+                    "example": "PropertyBlock.Status.Active"
                 }
             }
         },

--- a/services/main/docs/swagger.yaml
+++ b/services/main/docs/swagger.yaml
@@ -426,6 +426,13 @@ definitions:
         maxLength: 100
         minLength: 2
         type: string
+      status:
+        enum:
+        - PropertyBlock.Status.Active
+        - PropertyBlock.Status.Maintenance
+        - PropertyBlock.Status.Inactive
+        example: PropertyBlock.Status.Active
+        type: string
     type: object
   handlers.UpdatePropertyRequest:
     properties:

--- a/services/main/internal/handlers/property-block.go
+++ b/services/main/internal/handlers/property-block.go
@@ -185,9 +185,10 @@ func (h *PropertyBlockHandler) GetPropertyBlock(w http.ResponseWriter, r *http.R
 }
 
 type UpdatePropertyBlockRequest struct {
-	Name        *string   `json:"name,omitempty"        validate:"omitempty,min=2,max=100" example:"Luxury Apartment"`
-	Images      *[]string `json:"images,omitempty"      validate:"omitempty,dive,url"      example:"https://example.com/image1.jpg,https://example.com/image2.jpg"`
-	Description *string   `json:"description,omitempty" validate:"omitempty"               example:"Spacious apartment with sea view."`
+	Name        *string   `json:"name,omitempty"        validate:"omitempty,min=2,max=100"                                                                                    example:"Luxury Apartment"`
+	Images      *[]string `json:"images,omitempty"      validate:"omitempty,dive,url"                                                                                         example:"https://example.com/image1.jpg,https://example.com/image2.jpg"`
+	Description *string   `json:"description,omitempty" validate:"omitempty"                                                                                                  example:"Spacious apartment with sea view."`
+	Status      *string   `json:"status,omitempty"      validate:"omitempty,oneof=PropertyBlock.Status.Active PropertyBlock.Status.Maintenance PropertyBlock.Status.Inactive" example:"PropertyBlock.Status.Active"`
 }
 
 // UpdatePropertyBlock godoc
@@ -231,6 +232,7 @@ func (h *PropertyBlockHandler) UpdatePropertyBlock(w http.ResponseWriter, r *htt
 		Name:            body.Name,
 		Images:          body.Images,
 		Description:     body.Description,
+		Status:          body.Status,
 	}
 
 	updatedPropertyBlock, updatePropertyBlockErr := h.service.UpdatePropertyBlock(r.Context(), input)

--- a/services/main/internal/services/property-block.go
+++ b/services/main/internal/services/property-block.go
@@ -103,6 +103,7 @@ type UpdatePropertyBlockInput struct {
 	Name            *string
 	Description     *string
 	Images          *[]string
+	Status          *string
 }
 
 func (s *propertyBlockService) UpdatePropertyBlock(
@@ -134,6 +135,10 @@ func (s *propertyBlockService) UpdatePropertyBlock(
 
 	if input.Images != nil {
 		propertyBlock.Images = pq.StringArray(*input.Images)
+	}
+
+	if input.Status != nil {
+		propertyBlock.Status = *input.Status
 	}
 
 	propertyBlock.Description = input.Description


### PR DESCRIPTION
## PR Name or Description

Add "status" field to PropertyBlock update API

## Overview

This pull request introduces a new "status" field to the PropertyBlock update API, allowing clients to specify and update the status of a property block as Active, Maintenance, or Inactive.

## Detailed Technical Change

- Added a "status" field to the UpdatePropertyBlockRequest struct in internal/handlers/property-block.go, with validation and example.
- Updated the UpdatePropertyBlockInput struct in internal/services/property-block.go to include the "status" field.
- Modified the UpdatePropertyBlock handler and service logic to handle the new "status" field.
- Updated API documentation files (docs.go, swagger.json, swagger.yaml) to reflect the new "status" property with enum values and examples.

## Testing Approach & Result

- Verified that the API accepts and updates the "status" field correctly.
- Confirmed that the OpenAPI documentation reflects the new field and its allowed values.
- Manual testing performed via API requests to ensure correct behaviour.

## Result

Property block before updating status (currently active)
<img width="1447" height="958" alt="Screenshot 2025-12-13 at 6 02 19 PM" src="https://github.com/user-attachments/assets/1f342ae9-4969-45b6-aeba-1e3e2c201f53" />

Updating the property block status to inactive
<img width="1468" height="959" alt="Screenshot 2025-12-13 at 6 02 59 PM" src="https://github.com/user-attachments/assets/5de9a675-16a3-443e-b548-e1d2ef860210" />

Property block after updating status (currently inactive)
<img width="1456" height="958" alt="Screenshot 2025-12-13 at 6 03 19 PM" src="https://github.com/user-attachments/assets/681ca5b2-67df-4553-b592-e4e67b2385b3" />


## Related Work

N/A

## Documentation

API documentation updated in docs.go, swagger.json, and swagger.yaml.