### PR TITLE
Add support for "populate" query parameter to the GetCurrentClientUser endpoint

### DIFF
--- a/services/main/docs/docs.go
+++ b/services/main/docs/docs.go
@@ -1265,6 +1265,17 @@ const docTemplate = `{
                     "ClientUsers"
                 ],
                 "summary": "Get the currently authenticated client user",
+                "parameters": [
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "name": "populate",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",

--- a/services/main/docs/swagger.json
+++ b/services/main/docs/swagger.json
@@ -1257,6 +1257,17 @@
                     "ClientUsers"
                 ],
                 "summary": "Get the currently authenticated client user",
+                "parameters": [
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "name": "populate",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",

--- a/services/main/docs/swagger.yaml
+++ b/services/main/docs/swagger.yaml
@@ -2153,6 +2153,13 @@ paths:
       consumes:
       - application/json
       description: Get the currently authenticated client user
+      parameters:
+      - collectionFormat: csv
+        in: query
+        items:
+          type: string
+        name: populate
+        type: array
       produces:
       - application/json
       responses:

--- a/services/main/internal/handlers/client-user.go
+++ b/services/main/internal/handlers/client-user.go
@@ -137,6 +137,10 @@ func (h *ClientUserHandler) AuthenticateClientUser(w http.ResponseWriter, r *htt
 	})
 }
 
+type GetClientUserQuery struct {
+	lib.GetOneQueryInput
+}
+
 // GetCurrentClientUser godoc
 //
 //	@Summary		Get the currently authenticated client user
@@ -145,6 +149,7 @@ func (h *ClientUserHandler) AuthenticateClientUser(w http.ResponseWriter, r *htt
 //	@Accept			json
 //	@Security		BearerAuth
 //	@Produce		json
+//	@Param			q	query		GetClientUserQuery	true	"Client user"
 //	@Success		200	{object}	object{data=transformations.OutputClientUser}
 //	@Failure		400	{object}	lib.HTTPError
 //	@Failure		401	{object}	string
@@ -159,7 +164,14 @@ func (h *ClientUserHandler) GetMe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	clientUser, err := h.service.GetClientUser(r.Context(), currentClientUser.ID)
+	populateFields := GetPopulateFields(r)
+
+	query := repository.GetClientUserWithPopulateQuery{
+		ID:       currentClientUser.ID,
+		ClientID: currentClientUser.ClientID,
+		Populate: populateFields,
+	}
+	clientUser, err := h.service.GetClientUser(r.Context(), query)
 	if err != nil {
 		HandleErrorResponse(w, err)
 		return

--- a/services/main/internal/services/client-user.go
+++ b/services/main/internal/services/client-user.go
@@ -23,7 +23,7 @@ type ClientUserService interface {
 		ctx context.Context,
 		input AuthenticateClientUserInput,
 	) (*AuthenticateClientUserResponse, error)
-	GetClientUser(ctx context.Context, clientUserId string) (*models.ClientUser, error)
+	GetClientUser(ctx context.Context, query repository.GetClientUserWithPopulateQuery) (*models.ClientUser, error)
 	SendForgotPasswordResetLink(ctx context.Context, email string) (*models.ClientUser, error)
 	ResetPassword(
 		ctx context.Context,
@@ -223,9 +223,9 @@ func (s *clientUserService) AuthenticateClientUser(
 
 func (s *clientUserService) GetClientUser(
 	ctx context.Context,
-	clientUserId string,
+	query repository.GetClientUserWithPopulateQuery,
 ) (*models.ClientUser, error) {
-	clientUser, err := s.repo.GetByID(ctx, clientUserId)
+	clientUser, err := s.repo.GetByIDWithPopulate(ctx, query)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, pkg.NotFoundError("ClientUserNotFound", &pkg.RentLoopErrorParams{


### PR DESCRIPTION
## PR Name or Description

Add support for "populate" query parameter to the GetCurrentClientUser endpoint

## Overview

This pull request enhances the GetCurrentClientUser API endpoint to accept a "populate" query parameter, allowing clients to specify related fields to include in the response. The service and handler layers are updated to support this functionality.

## Detailed Technical Change

- Added `GetClientUserQuery` struct in `internal/handlers/client-user.go`.
- Modified the handler to parse the "populate" query parameter and construct a `GetClientUserWithPopulateQuery`.
- Updated the service interface and implementation in `internal/services/client-user.go` to accept the new query struct and call the repository method with population support.
- Updated OpenAPI documentation files (`docs.go`, `swagger.json`, `swagger.yaml`) to document the new query parameter.

## Testing Approach

- Manual testing of the endpoint with and without the "populate" parameter to verify the correct population of related fields.
- Confirmed that OpenAPI docs reflect the new parameter.

## Result 
<img width="1460" height="959" alt="Screenshot 2025-12-24 at 2 29 46 PM" src="https://github.com/user-attachments/assets/b4538012-15d8-4f57-ac66-e6b5d74f33cb" />

## Related Work

N/A

## Documentation

OpenAPI documentation updated in `docs.go`, `swagger.json`, and `swagger.yaml`.