### PR TITLE
Add client contact info fields (website, support phone/email) to Client model and API

### DIFF
--- a/services/main/docs/docs.go
+++ b/services/main/docs/docs.go
@@ -4968,6 +4968,14 @@ const docTemplate = `{
                     "type": "string",
                     "example": "LANDLORD"
                 },
+                "support_email": {
+                    "type": "string",
+                    "example": "support@somewebiste.com"
+                },
+                "support_phone": {
+                    "type": "string",
+                    "example": "+233551235555"
+                },
                 "type": {
                     "type": "string",
                     "example": "INDIVIDUAL"
@@ -4975,6 +4983,10 @@ const docTemplate = `{
                 "updated_at": {
                     "type": "string",
                     "example": "2023-01-01T00:00:00Z"
+                },
+                "website_url": {
+                    "type": "string",
+                    "example": "https://www.somewebiste.com"
                 }
             }
         },

--- a/services/main/docs/swagger.json
+++ b/services/main/docs/swagger.json
@@ -4960,6 +4960,14 @@
                     "type": "string",
                     "example": "LANDLORD"
                 },
+                "support_email": {
+                    "type": "string",
+                    "example": "support@somewebiste.com"
+                },
+                "support_phone": {
+                    "type": "string",
+                    "example": "+233551235555"
+                },
                 "type": {
                     "type": "string",
                     "example": "INDIVIDUAL"
@@ -4967,6 +4975,10 @@
                 "updated_at": {
                     "type": "string",
                     "example": "2023-01-01T00:00:00Z"
+                },
+                "website_url": {
+                    "type": "string",
+                    "example": "https://www.somewebiste.com"
                 }
             }
         },

--- a/services/main/docs/swagger.yaml
+++ b/services/main/docs/swagger.yaml
@@ -710,11 +710,20 @@ definitions:
       sub_type:
         example: LANDLORD
         type: string
+      support_email:
+        example: support@somewebiste.com
+        type: string
+      support_phone:
+        example: "+233551235555"
+        type: string
       type:
         example: INDIVIDUAL
         type: string
       updated_at:
         example: "2023-01-01T00:00:00Z"
+        type: string
+      website_url:
+        example: https://www.somewebiste.com
         type: string
     type: object
   transformations.OutputClientApplication:

--- a/services/main/init/migration/jobs/add-client-contact-info.go
+++ b/services/main/init/migration/jobs/add-client-contact-info.go
@@ -1,0 +1,34 @@
+package jobs
+
+import (
+	"github.com/Bendomey/rent-loop/services/main/internal/models"
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+func AddClientContactInfo() *gormigrate.Migration {
+	newFields := []string{"WebsiteUrl", "SupportPhone", "SupportEmail"}
+
+	return &gormigrate.Migration{
+		ID: "202512261025_ADD_CLIENT_CONTACT_INFO",
+		Migrate: func(db *gorm.DB) error {
+			for _, field := range newFields {
+				addFieldErr := CheckIfColumnExists(db, &models.Client{}, field)
+				if addFieldErr != nil {
+					return addFieldErr
+				}
+			}
+			return nil
+		},
+		Rollback: func(db *gorm.DB) error {
+			for _, field := range newFields {
+				removeFieldErr := DropColumnIfExists(db, &models.Client{}, field)
+				if removeFieldErr != nil {
+					return removeFieldErr
+				}
+			}
+
+			return nil
+		},
+	}
+}

--- a/services/main/init/migration/main.go
+++ b/services/main/init/migration/main.go
@@ -59,6 +59,7 @@ func ServiceAutoMigration(db *gorm.DB) error {
 
 	m = gormigrate.New(db, gormigrate.DefaultOptions, []*gormigrate.Migration{
 		jobs.SeedSuperAdmin(),
+		jobs.AddClientContactInfo(),
 	})
 	m.Migrate()
 

--- a/services/main/internal/models/client.go
+++ b/services/main/internal/models/client.go
@@ -8,12 +8,15 @@ type Client struct {
 	Name    string `gorm:"not null;"`       // company name or individual full name
 
 	// company address or individual home address
-	Address   string  `gorm:"not null;"`
-	Country   string  `gorm:"not null;"`
-	Region    string  `gorm:"not null;"`
-	City      string  `gorm:"not null;"`
-	Latitude  float64 `gorm:"not null;"`
-	Longitude float64 `gorm:"not null;"`
+	Address      string  `gorm:"not null;"`
+	Country      string  `gorm:"not null;"`
+	Region       string  `gorm:"not null;"`
+	City         string  `gorm:"not null;"`
+	Latitude     float64 `gorm:"not null;"`
+	Longitude    float64 `gorm:"not null;"`
+	WebsiteUrl   *string
+	SupportPhone *string
+	SupportEmail *string
 
 	ClientApplicationId string `gorm:"not null;"`
 	ClientApplication   ClientApplication

--- a/services/main/internal/services/client-application.go
+++ b/services/main/internal/services/client-application.go
@@ -262,6 +262,9 @@ func (s *clientApplicationService) ApproveClientApplication(
 		City:                clientApplication.City,
 		Longitude:           clientApplication.Longitude,
 		Latitude:            clientApplication.Latitude,
+		WebsiteUrl:          clientApplication.WebsiteURL,
+		SupportPhone:        clientApplication.SupportPhone,
+		SupportEmail:        clientApplication.SupportEmail,
 		ClientApplicationId: clientApplication.ID.String(),
 	}
 

--- a/services/main/internal/transformations/client.go
+++ b/services/main/internal/transformations/client.go
@@ -18,6 +18,9 @@ type OutputClient struct {
 	City                string                   `json:"city"                  example:"San Francisco"`
 	Latitude            float64                  `json:"latitude"              example:"37.7749"`
 	Longitude           float64                  `json:"longitude"             example:"-122.4194"`
+	WebsiteUrl          *string                  `json:"website_url"           example:"https://www.somewebiste.com"`
+	SupportPhone        *string                  `json:"support_phone"         example:"+233551235555"`
+	SupportEmail        *string                  `json:"support_email"         example:"support@somewebiste.com"`
 	ClientApplicationId string                   `json:"client_application_id" example:"app-1234"`
 	ClientApplication   *OutputClientApplication `json:"client_application"`
 	CreatedAt           time.Time                `json:"created_at"            example:"2023-01-01T00:00:00Z"`
@@ -40,6 +43,9 @@ func DBClientToRestClient(i *models.Client) interface{} {
 		"city":                  i.City,
 		"latitude":              i.Latitude,
 		"longitude":             i.Longitude,
+		"website_url":           i.WebsiteUrl,
+		"support_phone":         i.SupportPhone,
+		"support_email":         i.SupportEmail,
 		"client_application_id": i.ClientApplicationId,
 		"client_application":    DBClientApplicationToRestClientApplication(&i.ClientApplication),
 		"created_at":            i.CreatedAt,


### PR DESCRIPTION
## PR Name or Description

Add client contact info fields (website, support phone/email) to Client model and API

## Overview

This PR adds new contact information fields to the Client model: WebsiteUrl, SupportPhone, and SupportEmail. These fields are now available in the database, API responses, and documentation.

## Detailed Technical Change

- Updated `internal/models/client.go` to include WebsiteUrl, SupportPhone, and SupportEmail fields.
- Added migration job in `init/migration/jobs/add-client-contact-info.go` and registered it in `init/migration/main.go`.
- Updated transformation logic in `internal/transformations/client.go` to expose new fields in API responses.
- Modified service logic in `internal/services/client-application.go` to handle new fields.
- Updated API documentation in `docs/docs.go`, `docs/swagger.json`, and `docs/swagger.yaml` to reflect new fields.

## Testing Approach

- Ran migration to ensure new columns are added and can be rolled back.
- Verified API responses include the new fields.
- Checked documentation updates for accuracy.

## Result
<img width="1456" height="961" alt="Screenshot 2025-12-26 at 10 56 11 AM" src="https://github.com/user-attachments/assets/38876903-4066-4ad7-9c8c-5fcb9caa07ee" />

## Related Work

N/A

## Documentation

API documentation updated in swagger files and docs.go.