### PR TITLE
Add endpoints to update unit status (draft, available, maintenance) and related service logic

### DIFF
--- a/services/main/docs/docs.go
+++ b/services/main/docs/docs.go
@@ -3690,7 +3690,7 @@ const docTemplate = `{
                             "Unit.Status.Maintenance"
                         ],
                         "type": "string",
-                        "example": "Unit.Status.Active",
+                        "example": "Unit.Status.Available",
                         "name": "status",
                         "in": "query"
                     },
@@ -3982,6 +3982,219 @@ const docTemplate = `{
                     },
                     "422": {
                         "description": "Invalid request body",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "An unexpected error occurred",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/properties/{property_id}/units/{unit_id}/status:available": {
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update unit status to available",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Units"
+                ],
+                "summary": "Update unit status to available",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Property ID",
+                        "name": "property_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Unit ID",
+                        "name": "unit_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Unit status updated successfully"
+                    },
+                    "400": {
+                        "description": "Error occurred when updating unit status",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid or absent authentication token",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden access",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Unit not found",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "An unexpected error occurred",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/properties/{property_id}/units/{unit_id}/status:draft": {
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update unit status to draft",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Units"
+                ],
+                "summary": "Update unit status to draft",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Property ID",
+                        "name": "property_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Unit ID",
+                        "name": "unit_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Unit status updated successfully"
+                    },
+                    "400": {
+                        "description": "Error occurred when updating unit status",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid or absent authentication token",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden access",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Unit not found",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "An unexpected error occurred",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/properties/{property_id}/units/{unit_id}/status:maintenance": {
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update unit status to maintenance",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Units"
+                ],
+                "summary": "Update unit status to maintenance",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Property ID",
+                        "name": "property_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Unit ID",
+                        "name": "unit_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Unit status updated successfully"
+                    },
+                    "400": {
+                        "description": "Error occurred when updating unit status",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid or absent authentication token",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden access",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Unit not found",
                         "schema": {
                             "$ref": "#/definitions/lib.HTTPError"
                         }

--- a/services/main/docs/swagger.json
+++ b/services/main/docs/swagger.json
@@ -3682,7 +3682,7 @@
                             "Unit.Status.Maintenance"
                         ],
                         "type": "string",
-                        "example": "Unit.Status.Active",
+                        "example": "Unit.Status.Available",
                         "name": "status",
                         "in": "query"
                     },
@@ -3974,6 +3974,219 @@
                     },
                     "422": {
                         "description": "Invalid request body",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "An unexpected error occurred",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/properties/{property_id}/units/{unit_id}/status:available": {
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update unit status to available",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Units"
+                ],
+                "summary": "Update unit status to available",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Property ID",
+                        "name": "property_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Unit ID",
+                        "name": "unit_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Unit status updated successfully"
+                    },
+                    "400": {
+                        "description": "Error occurred when updating unit status",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid or absent authentication token",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden access",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Unit not found",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "An unexpected error occurred",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/properties/{property_id}/units/{unit_id}/status:draft": {
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update unit status to draft",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Units"
+                ],
+                "summary": "Update unit status to draft",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Property ID",
+                        "name": "property_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Unit ID",
+                        "name": "unit_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Unit status updated successfully"
+                    },
+                    "400": {
+                        "description": "Error occurred when updating unit status",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid or absent authentication token",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden access",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Unit not found",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "An unexpected error occurred",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/properties/{property_id}/units/{unit_id}/status:maintenance": {
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update unit status to maintenance",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Units"
+                ],
+                "summary": "Update unit status to maintenance",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Property ID",
+                        "name": "property_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Unit ID",
+                        "name": "unit_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Unit status updated successfully"
+                    },
+                    "400": {
+                        "description": "Error occurred when updating unit status",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid or absent authentication token",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden access",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Unit not found",
                         "schema": {
                             "$ref": "#/definitions/lib.HTTPError"
                         }

--- a/services/main/docs/swagger.yaml
+++ b/services/main/docs/swagger.yaml
@@ -3373,7 +3373,7 @@ paths:
         - Unit.Status.Available
         - Unit.Status.Occupied
         - Unit.Status.Maintenance
-        example: Unit.Status.Active
+        example: Unit.Status.Available
         in: query
         name: status
         type: string
@@ -3577,6 +3577,144 @@ paths:
       security:
       - BearerAuth: []
       summary: Update unit
+      tags:
+      - Units
+  /api/v1/properties/{property_id}/units/{unit_id}/status:available:
+    patch:
+      consumes:
+      - application/json
+      description: Update unit status to available
+      parameters:
+      - description: Property ID
+        in: path
+        name: property_id
+        required: true
+        type: string
+      - description: Unit ID
+        in: path
+        name: unit_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: Unit status updated successfully
+        "400":
+          description: Error occurred when updating unit status
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "401":
+          description: Invalid or absent authentication token
+          schema:
+            type: string
+        "403":
+          description: Forbidden access
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "404":
+          description: Unit not found
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "500":
+          description: An unexpected error occurred
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Update unit status to available
+      tags:
+      - Units
+  /api/v1/properties/{property_id}/units/{unit_id}/status:draft:
+    patch:
+      consumes:
+      - application/json
+      description: Update unit status to draft
+      parameters:
+      - description: Property ID
+        in: path
+        name: property_id
+        required: true
+        type: string
+      - description: Unit ID
+        in: path
+        name: unit_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: Unit status updated successfully
+        "400":
+          description: Error occurred when updating unit status
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "401":
+          description: Invalid or absent authentication token
+          schema:
+            type: string
+        "403":
+          description: Forbidden access
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "404":
+          description: Unit not found
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "500":
+          description: An unexpected error occurred
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Update unit status to draft
+      tags:
+      - Units
+  /api/v1/properties/{property_id}/units/{unit_id}/status:maintenance:
+    patch:
+      consumes:
+      - application/json
+      description: Update unit status to maintenance
+      parameters:
+      - description: Property ID
+        in: path
+        name: property_id
+        required: true
+        type: string
+      - description: Unit ID
+        in: path
+        name: unit_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: Unit status updated successfully
+        "400":
+          description: Error occurred when updating unit status
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "401":
+          description: Invalid or absent authentication token
+          schema:
+            type: string
+        "403":
+          description: Forbidden access
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "404":
+          description: Unit not found
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "500":
+          description: An unexpected error occurred
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Update unit status to maintenance
       tags:
       - Units
   /api/v1/properties/me:

--- a/services/main/internal/handlers/unit.go
+++ b/services/main/internal/handlers/unit.go
@@ -109,10 +109,10 @@ func (h *UnitHandler) CreateUnit(w http.ResponseWriter, r *http.Request) {
 type ListUnitsFilterRequest struct {
 	lib.FilterQueryInput
 	PropertyID       string   `json:"property_id"       validate:"omitempty"                                                                                            example:"prop_123"                                                                  description:"ID of the property to filter units by"`
-	Status           string   `json:"status"            validate:"omitempty,oneof=Unit.Status.Draft Unit.Status.Available Unit.Status.Occupied Unit.Status.Maintenance" example:"Unit.Status.Active"                                                        description:"Status of the unit. Allowed values: Unit.Status.Active, Unit.Status.Inactive, Unit.Status.Maintenance"`
+	Status           string   `json:"status"            validate:"omitempty,oneof=Unit.Status.Draft Unit.Status.Available Unit.Status.Occupied Unit.Status.Maintenance" example:"Unit.Status.Available"                                                     description:"Status of the unit. Allowed values: Unit.Status.Draft, Unit.Status.Available, Unit.Status.Occupied, Unit.Status.Maintenance"`
 	Type             string   `json:"type"              validate:"omitempty,oneof=APARTMENT HOUSE STUDIO OFFICE RETAIL"                                                 example:"SINGLE"                                                                    description:"Type of unit. Allowed values: SINGLE, MULTI"`
 	PaymentFrequency string   `json:"payment_frequency" validate:"omitempty,oneof=WEEKLY DAILY MONTHLY QUARTERLY BIANNUALLY ANNUALLY"                                   example:"WEEKLY"                                                                    description:"Payment frequency. Allowed values: WEEKLY, DAILY, MONTHLY, QUARTERLY, BIANNUALLY, ANNUALLY"`
-	BlockIDs         []string `json:"block_ids"         validate:"omitempty,dive,uuid"                                                                                  example:"767d8e23-8c9f-4c51-85af-5908039869da,3d90d606-2a22-4487-9431-69736829094f" description:"List of block IDs to filter units by"                                                                  collectionFormat:"multi"`
+	BlockIDs         []string `json:"block_ids"         validate:"omitempty,dive,uuid"                                                                                  example:"767d8e23-8c9f-4c51-85af-5908039869da,3d90d606-2a22-4487-9431-69736829094f" description:"List of block IDs to filter units by"                                                                                        collectionFormat:"multi"`
 }
 
 // ListUnits godoc
@@ -290,6 +290,114 @@ func (h *UnitHandler) UpdateUnit(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(map[string]any{
 		"data": transformations.DBUnitToRest(unit),
 	})
+}
+
+// UpdateUnitToDraftStatus godoc
+//
+//	@Summary		Update unit status to draft
+//	@Description	Update unit status to draft
+//	@Tags			Units
+//	@Accept			json
+//	@Security		BearerAuth
+//	@Produce		json
+//	@Param			property_id	path		string			true	"Property ID"
+//	@Param			unit_id		path		string			true	"Unit ID"
+//	@Success		204			{object}	nil				"Unit status updated successfully"
+//	@Failure		400			{object}	lib.HTTPError	"Error occurred when updating unit status"
+//	@Failure		401			{object}	string			"Invalid or absent authentication token"
+//	@Failure		403			{object}	lib.HTTPError	"Forbidden access"
+//	@Failure		404			{object}	lib.HTTPError	"Unit not found"
+//	@Failure		500			{object}	string			"An unexpected error occurred"
+//	@Router			/api/v1/properties/{property_id}/units/{unit_id}/status:draft [patch]
+func (h *UnitHandler) UpdateUnitToDraftStatus(w http.ResponseWriter, r *http.Request) {
+	propertyID := chi.URLParam(r, "property_id")
+	unitID := chi.URLParam(r, "unit_id")
+
+	input := services.UpdateUnitStatusInput{
+		PropertyID: propertyID,
+		UnitID:     unitID,
+		Status:     "Unit.Status.Draft",
+	}
+
+	updateUnitStatusErr := h.service.UpdateUnitStatus(r.Context(), input)
+	if updateUnitStatusErr != nil {
+		HandleErrorResponse(w, updateUnitStatusErr)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// UpdateUnitToMaintenanceStatus godoc
+//
+//	@Summary		Update unit status to maintenance
+//	@Description	Update unit status to maintenance
+//	@Tags			Units
+//	@Accept			json
+//	@Security		BearerAuth
+//	@Produce		json
+//	@Param			property_id	path		string			true	"Property ID"
+//	@Param			unit_id		path		string			true	"Unit ID"
+//	@Success		204			{object}	nil				"Unit status updated successfully"
+//	@Failure		400			{object}	lib.HTTPError	"Error occurred when updating unit status"
+//	@Failure		401			{object}	string			"Invalid or absent authentication token"
+//	@Failure		403			{object}	lib.HTTPError	"Forbidden access"
+//	@Failure		404			{object}	lib.HTTPError	"Unit not found"
+//	@Failure		500			{object}	string			"An unexpected error occurred"
+//	@Router			/api/v1/properties/{property_id}/units/{unit_id}/status:maintenance [patch]
+func (h *UnitHandler) UpdateUnitToMaintenanceStatus(w http.ResponseWriter, r *http.Request) {
+	propertyID := chi.URLParam(r, "property_id")
+	unitID := chi.URLParam(r, "unit_id")
+
+	input := services.UpdateUnitStatusInput{
+		PropertyID: propertyID,
+		UnitID:     unitID,
+		Status:     "Unit.Status.Maintenance",
+	}
+
+	updateUnitStatusErr := h.service.UpdateUnitStatus(r.Context(), input)
+	if updateUnitStatusErr != nil {
+		HandleErrorResponse(w, updateUnitStatusErr)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// UpdateUnitToAvailableStatus godoc
+//
+//	@Summary		Update unit status to available
+//	@Description	Update unit status to available
+//	@Tags			Units
+//	@Accept			json
+//	@Security		BearerAuth
+//	@Produce		json
+//	@Param			property_id	path		string			true	"Property ID"
+//	@Param			unit_id		path		string			true	"Unit ID"
+//	@Success		204			{object}	nil				"Unit status updated successfully"
+//	@Failure		400			{object}	lib.HTTPError	"Error occurred when updating unit status"
+//	@Failure		401			{object}	string			"Invalid or absent authentication token"
+//	@Failure		403			{object}	lib.HTTPError	"Forbidden access"
+//	@Failure		404			{object}	lib.HTTPError	"Unit not found"
+//	@Failure		500			{object}	string			"An unexpected error occurred"
+//	@Router			/api/v1/properties/{property_id}/units/{unit_id}/status:available [patch]
+func (h *UnitHandler) UpdateUnitToAvailableStatus(w http.ResponseWriter, r *http.Request) {
+	propertyID := chi.URLParam(r, "property_id")
+	unitID := chi.URLParam(r, "unit_id")
+
+	input := services.UpdateUnitStatusInput{
+		PropertyID: propertyID,
+		UnitID:     unitID,
+		Status:     "Unit.Status.Available",
+	}
+
+	updateUnitStatusErr := h.service.UpdateUnitStatus(r.Context(), input)
+	if updateUnitStatusErr != nil {
+		HandleErrorResponse(w, updateUnitStatusErr)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // DeleteUnit godoc

--- a/services/main/internal/router/client-user.go
+++ b/services/main/internal/router/client-user.go
@@ -101,6 +101,12 @@ func NewClientUserRouter(appCtx pkg.AppContext, handlers handlers.Handlers) func
 								Patch("/", handlers.UnitHandler.UpdateUnit)
 							r.With(middlewares.ValidateRoleClientUserPropertyMiddleware(appCtx, "MANAGER")).
 								Delete("/", handlers.UnitHandler.DeleteUnit)
+							r.With(middlewares.ValidateRoleClientUserPropertyMiddleware(appCtx, "MANAGER")).
+								Patch("/status:draft", handlers.UnitHandler.UpdateUnitToDraftStatus)
+							r.With(middlewares.ValidateRoleClientUserPropertyMiddleware(appCtx, "MANAGER")).
+								Patch("/status:maintenance", handlers.UnitHandler.UpdateUnitToMaintenanceStatus)
+							r.With(middlewares.ValidateRoleClientUserPropertyMiddleware(appCtx, "MANAGER")).
+								Patch("/status:available", handlers.UnitHandler.UpdateUnitToAvailableStatus)
 						})
 					})
 				})


### PR DESCRIPTION
## PR Name or Description

Add endpoints to update unit status (draft, available, maintenance) and related service logic

## Overview

This PR introduces new PATCH endpoints to update a unit's status to "draft", "available", or "maintenance". It also adds the necessary service logic, handler methods, and updates API documentation.

## Detailed Technical Change

- Added three new handler methods in `internal/handlers/unit.go` for updating unit status to draft, available, or maintenance.
- Implemented `UpdateUnitStatus` and supporting input struct in `internal/services/unit.go`.
- Registered new endpoints in `internal/router/client-user.go` with appropriate middleware.
- Updated API documentation in `docs/docs.go`, `docs/swagger.json`, and `docs/swagger.yaml`.
- Updated the `ListUnitsFilterRequest` struct to correct the status example and description.

## Testing Approach

- Verified new endpoints are registered and protected by the correct middleware.
- Confirmed status updates work as expected and return appropriate HTTP responses.
- Checked that API documentation reflects the new endpoints and parameters.

## Result

### Update Status To Available

Unit of Status Draft Before Updating
<img width="1452" height="958" alt="Screenshot 2025-12-26 at 12 44 29 PM" src="https://github.com/user-attachments/assets/95ee6924-2129-41e0-9ea2-0ec32bd31f47" />

Unit of Status Draft Updated To Available
<img width="1453" height="959" alt="Screenshot 2025-12-26 at 12 45 00 PM" src="https://github.com/user-attachments/assets/fb407d18-162a-4128-85d0-17926002cc39" />

Unit After Updating Status
<img width="1454" height="958" alt="Screenshot 2025-12-26 at 12 45 25 PM" src="https://github.com/user-attachments/assets/c64874de-27cd-42e6-aede-9fedd0234971" />

Unit of Status Maintenance Before Updating
<img width="1457" height="959" alt="Screenshot 2025-12-26 at 12 48 16 PM" src="https://github.com/user-attachments/assets/bcadc390-a78f-4182-b5db-014470b59b00" />

Unit of Status Maintenance Updated to Available
<img width="1453" height="959" alt="Screenshot 2025-12-26 at 12 45 00 PM" src="https://github.com/user-attachments/assets/fb407d18-162a-4128-85d0-17926002cc39" />

Unit After Updating Status
<img width="1453" height="960" alt="Screenshot 2025-12-26 at 12 48 52 PM" src="https://github.com/user-attachments/assets/48d21aff-c121-4a16-8938-9f0257f95b21" />

Unit of Status Occupied Before Updating
<img width="1453" height="961" alt="Screenshot 2025-12-26 at 12 39 02 PM" src="https://github.com/user-attachments/assets/a07aff43-93e9-4801-b089-7e9f9badd7bb" />

Unit of Status Occupied Updated to Available
<img width="1441" height="959" alt="Screenshot 2025-12-26 at 12 38 33 PM" src="https://github.com/user-attachments/assets/5be24c2d-ffe3-496a-b87c-03f7781b1865" />

### Update Status To Draft

Unit of Status Available Before Updating
<img width="1457" height="960" alt="Screenshot 2025-12-26 at 12 51 52 PM" src="https://github.com/user-attachments/assets/2aa1fd58-41fd-43ba-8ff4-ce4ecc5ea470" />

Unit of Status Available Updated To Draft
<img width="1460" height="958" alt="Screenshot 2025-12-26 at 12 52 26 PM" src="https://github.com/user-attachments/assets/7db771a5-68df-45e5-be5c-df2b1ee9584c" />

Unit After Updating Status
<img width="1440" height="959" alt="Screenshot 2025-12-26 at 12 52 46 PM" src="https://github.com/user-attachments/assets/0e949a9f-42ff-4460-a42c-5d5bd0984c19" />

Unit of Status Maintenance Before Updating
<img width="1458" height="958" alt="Screenshot 2025-12-26 at 1 01 06 PM" src="https://github.com/user-attachments/assets/0a1270ba-071d-4090-87db-d402859ad869" />

Unit of Status Maintenance Updated to Draft
<img width="1460" height="958" alt="Screenshot 2025-12-26 at 12 52 26 PM" src="https://github.com/user-attachments/assets/7db771a5-68df-45e5-be5c-df2b1ee9584c" />

Unit After Updating Status
<img width="1444" height="959" alt="Screenshot 2025-12-26 at 12 54 35 PM" src="https://github.com/user-attachments/assets/a7a535e0-b4c4-4ada-aaeb-1abf37c4d154" />

Unit of Status Occupied Before Updating
<img width="1466" height="958" alt="Screenshot 2025-12-26 at 12 55 40 PM" src="https://github.com/user-attachments/assets/76a506fc-b806-402a-be47-f5b91f37929d" />

Unit of Status Occupied Updated to Available
<img width="1468" height="959" alt="Screenshot 2025-12-26 at 12 37 57 PM" src="https://github.com/user-attachments/assets/e60f80f3-29b3-48f4-abe3-f34baca403a9" />

### Update Status To Maintenance

Unit of Status Available Before Updating
<img width="1445" height="958" alt="Screenshot 2025-12-26 at 12 58 26 PM" src="https://github.com/user-attachments/assets/c223ba17-f8c6-44ed-aad0-aaf19c86b662" />

Unit of Status Available Updated To Maintenance
<img width="1446" height="959" alt="Screenshot 2025-12-26 at 12 58 46 PM" src="https://github.com/user-attachments/assets/38aba458-9bcd-4961-94d6-32eb8110e263" />

Unit After Updating Status
<img width="1463" height="960" alt="Screenshot 2025-12-26 at 12 59 38 PM" src="https://github.com/user-attachments/assets/e235e903-8524-4a28-8768-cf0ce76ebf0d" />

Unit of Status Draft Before Updating
<img width="1440" height="959" alt="Screenshot 2025-12-26 at 12 52 46 PM" src="https://github.com/user-attachments/assets/0e949a9f-42ff-4460-a42c-5d5bd0984c19" />

Unit of Status Draft Updated to Maintenance
<img width="1457" height="958" alt="Screenshot 2025-12-26 at 1 45 19 PM" src="https://github.com/user-attachments/assets/619af8c0-9bf5-4d3b-b7ce-66861bb119df" />

Unit After Updating Status
<img width="1447" height="959" alt="Screenshot 2025-12-26 at 12 53 49 PM" src="https://github.com/user-attachments/assets/e783eb6b-788a-4e57-85ef-a5a949e48720" />

Unit of Status Occupied Before Updating
<img width="1453" height="961" alt="Screenshot 2025-12-26 at 12 39 02 PM" src="https://github.com/user-attachments/assets/a07aff43-93e9-4801-b089-7e9f9badd7bb" />

Unit of Status Occupied Updated to Available
<img width="1455" height="958" alt="Screenshot 2025-12-26 at 12 38 10 PM" src="https://github.com/user-attachments/assets/2b5771ad-7f69-44e2-bbb0-cab945101b6f" />

## Related Work

N/A

## Documentation

API documentation updated in `swagger.yaml`, `swagger.json`, and `docs.go`.