### PR TITLE
Add Get Tenant Application Endpoint and Supporting Logic

### DIFF
--- a/services/main/docs/docs.go
+++ b/services/main/docs/docs.go
@@ -4564,6 +4564,81 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/api/v1/tenant-applications/{tenant_application_id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get tenant application",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "TenantApplication"
+                ],
+                "summary": "Get tenant application",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Tenant application ID",
+                        "name": "tenant_application_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "name": "populate",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Tenant application retrieved successfully",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "$ref": "#/definitions/transformations.OutputTenantApplication"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Error occurred when fetching a tenant application",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid or absent authentication token",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Tenant application not found",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "An unexpected error occurred",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {

--- a/services/main/docs/swagger.json
+++ b/services/main/docs/swagger.json
@@ -4556,6 +4556,81 @@
                     }
                 }
             }
+        },
+        "/api/v1/tenant-applications/{tenant_application_id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get tenant application",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "TenantApplication"
+                ],
+                "summary": "Get tenant application",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Tenant application ID",
+                        "name": "tenant_application_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "name": "populate",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Tenant application retrieved successfully",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "$ref": "#/definitions/transformations.OutputTenantApplication"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Error occurred when fetching a tenant application",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid or absent authentication token",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Tenant application not found",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "An unexpected error occurred",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {

--- a/services/main/docs/swagger.yaml
+++ b/services/main/docs/swagger.yaml
@@ -4300,6 +4300,54 @@ paths:
       summary: Create a new tenant application
       tags:
       - TenantApplication
+  /api/v1/tenant-applications/{tenant_application_id}:
+    get:
+      consumes:
+      - application/json
+      description: Get tenant application
+      parameters:
+      - description: Tenant application ID
+        in: path
+        name: tenant_application_id
+        required: true
+        type: string
+      - collectionFormat: csv
+        in: query
+        items:
+          type: string
+        name: populate
+        type: array
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Tenant application retrieved successfully
+          schema:
+            properties:
+              data:
+                $ref: '#/definitions/transformations.OutputTenantApplication'
+            type: object
+        "400":
+          description: Error occurred when fetching a tenant application
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "401":
+          description: Invalid or absent authentication token
+          schema:
+            type: string
+        "404":
+          description: Tenant application not found
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "500":
+          description: An unexpected error occurred
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Get tenant application
+      tags:
+      - TenantApplication
   /api/v1/tenant-applications/invite:
     post:
       consumes:

--- a/services/main/internal/router/client-user.go
+++ b/services/main/internal/router/client-user.go
@@ -137,6 +137,7 @@ func NewClientUserRouter(appCtx pkg.AppContext, handlers handlers.Handlers) func
 				r.With(middlewares.ValidateRoleClientUserMiddleware(appCtx, "ADMIN", "OWNER")).
 					Post("/invite", handlers.TenantApplicationHandler.SendTenantInvite)
 				r.Get("/", handlers.TenantApplicationHandler.ListTenantApplications)
+				r.Get("/{tenant_application_id}", handlers.TenantApplicationHandler.GetTenantApplication)
 			})
 		})
 	}


### PR DESCRIPTION
## PR Name or Description

Add Get Tenant Application Endpoint and Supporting Logic

## Overview

This pull request introduces a new API endpoint to retrieve a single tenant application by its ID. It includes handler, service, repository, and route updates, as well as documentation changes.

## Detailed Technical Change

- Added `GetTenantApplication` handler in `internal/handlers/tenant-application.go`
- Introduced `GetTenantApplicationQuery` struct and related logic
- Implemented `GetOneWithQuery` in the repository (`internal/repository/tenant-application.go`)
- Added `GetOneTenantApplication` method in the service layer (`internal/services/tenant-application.go`)
- Registered the new route in `internal/router/client-user.go`
- Updated API documentation in `docs/docs.go`, `docs/swagger.json`, and `docs/swagger.yaml`

## Testing Approach

- Manual testing via API client (e.g., Postman) to ensure the endpoint returns the correct tenant application data and handles errors as expected
- Verified correct HTTP status codes and response structure
- Confirmed documentation updates reflect the new endpoint

## Result

<img width="1437" height="1006" alt="Screenshot 2026-01-10 at 1 26 58 PM" src="https://github.com/user-attachments/assets/a5820a68-98ab-4b69-b708-a4cb96f292b0" />

## Related Work

N/A

## Documentation

API documentation updated in `docs/docs.go`, `docs/swagger.json`, and `docs/swagger.yaml`