### PR TITLE
Add unauthorized endpoint to fetch unit subset and refactor admin unit output

### DIFF
--- a/services/main/docs/docs.go
+++ b/services/main/docs/docs.go
@@ -3415,7 +3415,7 @@ const docTemplate = `{
                             "type": "object",
                             "properties": {
                                 "data": {
-                                    "$ref": "#/definitions/transformations.OutputUnit"
+                                    "$ref": "#/definitions/transformations.AdminOutputUnit"
                                 }
                             }
                         }
@@ -3723,7 +3723,7 @@ const docTemplate = `{
                                         "rows": {
                                             "type": "array",
                                             "items": {
-                                                "$ref": "#/definitions/transformations.OutputUnit"
+                                                "$ref": "#/definitions/transformations.AdminOutputUnit"
                                             }
                                         }
                                     }
@@ -3802,7 +3802,7 @@ const docTemplate = `{
                             "type": "object",
                             "properties": {
                                 "data": {
-                                    "$ref": "#/definitions/transformations.OutputUnit"
+                                    "$ref": "#/definitions/transformations.AdminOutputUnit"
                                 }
                             }
                         }
@@ -3951,7 +3951,7 @@ const docTemplate = `{
                             "type": "object",
                             "properties": {
                                 "data": {
-                                    "$ref": "#/definitions/transformations.OutputUnit"
+                                    "$ref": "#/definitions/transformations.AdminOutputUnit"
                                 }
                             }
                         }
@@ -4706,6 +4706,61 @@ const docTemplate = `{
                     },
                     "422": {
                         "description": "Validation error",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "An unexpected error occurred",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/units/{unit_id}": {
+            "get": {
+                "description": "Fetch unit subset",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Units"
+                ],
+                "summary": "Fetch unit subset",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Unit ID",
+                        "name": "unit_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "$ref": "#/definitions/transformations.OutputUnit"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Error occurred when fetching a unit",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Unit not found",
                         "schema": {
                             "$ref": "#/definitions/lib.HTTPError"
                         }
@@ -5932,6 +5987,113 @@ const docTemplate = `{
                 }
             }
         },
+        "transformations.AdminOutputUnit": {
+            "type": "object",
+            "properties": {
+                "area": {
+                    "type": "number",
+                    "example": 120.5
+                },
+                "created_at": {
+                    "type": "string",
+                    "format": "date-time",
+                    "example": "2023-01-01T00:00:00Z"
+                },
+                "created_by": {
+                    "$ref": "#/definitions/transformations.OutputClientUser"
+                },
+                "created_by_id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "example": "1e81fea0-5e8b-4535-b449-1a2133e94a7a"
+                },
+                "description": {
+                    "type": "string",
+                    "example": "Spacious apartment with balcony"
+                },
+                "features": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "example": "4fce5dc8-8114-4ab2-a94b-b4536c27f43b"
+                },
+                "images": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "http://www.images/unit101.jpg"
+                    ]
+                },
+                "max_occupants_allowed": {
+                    "type": "integer",
+                    "example": 4
+                },
+                "name": {
+                    "type": "string",
+                    "example": "Unit 101"
+                },
+                "payment_frequency": {
+                    "type": "string",
+                    "example": "MONTHLY"
+                },
+                "property": {
+                    "$ref": "#/definitions/transformations.OutputProperty"
+                },
+                "property_block": {
+                    "$ref": "#/definitions/transformations.OutputPropertyBlock"
+                },
+                "property_block_id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "example": "a12345ee-1a70-436e-ba24-572078895982"
+                },
+                "property_id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "example": "b50874ee-1a70-436e-ba24-572078895982"
+                },
+                "rent_fee": {
+                    "type": "integer",
+                    "example": 1500
+                },
+                "rent_fee_currency": {
+                    "type": "string",
+                    "example": "USD"
+                },
+                "slug": {
+                    "type": "string",
+                    "example": "unit-101-abcde1876drkjy"
+                },
+                "status": {
+                    "type": "string",
+                    "example": "Unit.Status.Available"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "apartment",
+                        "balcony"
+                    ]
+                },
+                "type": {
+                    "type": "string",
+                    "example": "APARTMENT"
+                },
+                "updated_at": {
+                    "type": "string",
+                    "format": "date-time",
+                    "example": "2023-01-01T00:00:00Z"
+                }
+            }
+        },
         "transformations.OutputAdmin": {
             "type": "object",
             "properties": {
@@ -6730,19 +6892,6 @@ const docTemplate = `{
                     "type": "number",
                     "example": 120.5
                 },
-                "created_at": {
-                    "type": "string",
-                    "format": "date-time",
-                    "example": "2023-01-01T00:00:00Z"
-                },
-                "created_by": {
-                    "$ref": "#/definitions/transformations.OutputClientUser"
-                },
-                "created_by_id": {
-                    "type": "string",
-                    "format": "uuid",
-                    "example": "1e81fea0-5e8b-4535-b449-1a2133e94a7a"
-                },
                 "description": {
                     "type": "string",
                     "example": "Spacious apartment with balcony"
@@ -6765,10 +6914,6 @@ const docTemplate = `{
                         "http://www.images/unit101.jpg"
                     ]
                 },
-                "max_occupants_allowed": {
-                    "type": "integer",
-                    "example": 4
-                },
                 "name": {
                     "type": "string",
                     "example": "Unit 101"
@@ -6776,22 +6921,6 @@ const docTemplate = `{
                 "payment_frequency": {
                     "type": "string",
                     "example": "MONTHLY"
-                },
-                "property": {
-                    "$ref": "#/definitions/transformations.OutputProperty"
-                },
-                "property_block": {
-                    "$ref": "#/definitions/transformations.OutputPropertyBlock"
-                },
-                "property_block_id": {
-                    "type": "string",
-                    "format": "uuid",
-                    "example": "a12345ee-1a70-436e-ba24-572078895982"
-                },
-                "property_id": {
-                    "type": "string",
-                    "format": "uuid",
-                    "example": "b50874ee-1a70-436e-ba24-572078895982"
                 },
                 "rent_fee": {
                     "type": "integer",
@@ -6804,10 +6933,6 @@ const docTemplate = `{
                 "slug": {
                     "type": "string",
                     "example": "unit-101-abcde1876drkjy"
-                },
-                "status": {
-                    "type": "string",
-                    "example": "Unit.Status.Available"
                 },
                 "tags": {
                     "type": "array",
@@ -6822,11 +6947,6 @@ const docTemplate = `{
                 "type": {
                     "type": "string",
                     "example": "APARTMENT"
-                },
-                "updated_at": {
-                    "type": "string",
-                    "format": "date-time",
-                    "example": "2023-01-01T00:00:00Z"
                 }
             }
         }

--- a/services/main/docs/swagger.json
+++ b/services/main/docs/swagger.json
@@ -3407,7 +3407,7 @@
                             "type": "object",
                             "properties": {
                                 "data": {
-                                    "$ref": "#/definitions/transformations.OutputUnit"
+                                    "$ref": "#/definitions/transformations.AdminOutputUnit"
                                 }
                             }
                         }
@@ -3715,7 +3715,7 @@
                                         "rows": {
                                             "type": "array",
                                             "items": {
-                                                "$ref": "#/definitions/transformations.OutputUnit"
+                                                "$ref": "#/definitions/transformations.AdminOutputUnit"
                                             }
                                         }
                                     }
@@ -3794,7 +3794,7 @@
                             "type": "object",
                             "properties": {
                                 "data": {
-                                    "$ref": "#/definitions/transformations.OutputUnit"
+                                    "$ref": "#/definitions/transformations.AdminOutputUnit"
                                 }
                             }
                         }
@@ -3943,7 +3943,7 @@
                             "type": "object",
                             "properties": {
                                 "data": {
-                                    "$ref": "#/definitions/transformations.OutputUnit"
+                                    "$ref": "#/definitions/transformations.AdminOutputUnit"
                                 }
                             }
                         }
@@ -4698,6 +4698,61 @@
                     },
                     "422": {
                         "description": "Validation error",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "An unexpected error occurred",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/units/{unit_id}": {
+            "get": {
+                "description": "Fetch unit subset",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Units"
+                ],
+                "summary": "Fetch unit subset",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Unit ID",
+                        "name": "unit_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "$ref": "#/definitions/transformations.OutputUnit"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Error occurred when fetching a unit",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Unit not found",
                         "schema": {
                             "$ref": "#/definitions/lib.HTTPError"
                         }
@@ -5924,6 +5979,113 @@
                 }
             }
         },
+        "transformations.AdminOutputUnit": {
+            "type": "object",
+            "properties": {
+                "area": {
+                    "type": "number",
+                    "example": 120.5
+                },
+                "created_at": {
+                    "type": "string",
+                    "format": "date-time",
+                    "example": "2023-01-01T00:00:00Z"
+                },
+                "created_by": {
+                    "$ref": "#/definitions/transformations.OutputClientUser"
+                },
+                "created_by_id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "example": "1e81fea0-5e8b-4535-b449-1a2133e94a7a"
+                },
+                "description": {
+                    "type": "string",
+                    "example": "Spacious apartment with balcony"
+                },
+                "features": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "example": "4fce5dc8-8114-4ab2-a94b-b4536c27f43b"
+                },
+                "images": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "http://www.images/unit101.jpg"
+                    ]
+                },
+                "max_occupants_allowed": {
+                    "type": "integer",
+                    "example": 4
+                },
+                "name": {
+                    "type": "string",
+                    "example": "Unit 101"
+                },
+                "payment_frequency": {
+                    "type": "string",
+                    "example": "MONTHLY"
+                },
+                "property": {
+                    "$ref": "#/definitions/transformations.OutputProperty"
+                },
+                "property_block": {
+                    "$ref": "#/definitions/transformations.OutputPropertyBlock"
+                },
+                "property_block_id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "example": "a12345ee-1a70-436e-ba24-572078895982"
+                },
+                "property_id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "example": "b50874ee-1a70-436e-ba24-572078895982"
+                },
+                "rent_fee": {
+                    "type": "integer",
+                    "example": 1500
+                },
+                "rent_fee_currency": {
+                    "type": "string",
+                    "example": "USD"
+                },
+                "slug": {
+                    "type": "string",
+                    "example": "unit-101-abcde1876drkjy"
+                },
+                "status": {
+                    "type": "string",
+                    "example": "Unit.Status.Available"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "apartment",
+                        "balcony"
+                    ]
+                },
+                "type": {
+                    "type": "string",
+                    "example": "APARTMENT"
+                },
+                "updated_at": {
+                    "type": "string",
+                    "format": "date-time",
+                    "example": "2023-01-01T00:00:00Z"
+                }
+            }
+        },
         "transformations.OutputAdmin": {
             "type": "object",
             "properties": {
@@ -6722,19 +6884,6 @@
                     "type": "number",
                     "example": 120.5
                 },
-                "created_at": {
-                    "type": "string",
-                    "format": "date-time",
-                    "example": "2023-01-01T00:00:00Z"
-                },
-                "created_by": {
-                    "$ref": "#/definitions/transformations.OutputClientUser"
-                },
-                "created_by_id": {
-                    "type": "string",
-                    "format": "uuid",
-                    "example": "1e81fea0-5e8b-4535-b449-1a2133e94a7a"
-                },
                 "description": {
                     "type": "string",
                     "example": "Spacious apartment with balcony"
@@ -6757,10 +6906,6 @@
                         "http://www.images/unit101.jpg"
                     ]
                 },
-                "max_occupants_allowed": {
-                    "type": "integer",
-                    "example": 4
-                },
                 "name": {
                     "type": "string",
                     "example": "Unit 101"
@@ -6768,22 +6913,6 @@
                 "payment_frequency": {
                     "type": "string",
                     "example": "MONTHLY"
-                },
-                "property": {
-                    "$ref": "#/definitions/transformations.OutputProperty"
-                },
-                "property_block": {
-                    "$ref": "#/definitions/transformations.OutputPropertyBlock"
-                },
-                "property_block_id": {
-                    "type": "string",
-                    "format": "uuid",
-                    "example": "a12345ee-1a70-436e-ba24-572078895982"
-                },
-                "property_id": {
-                    "type": "string",
-                    "format": "uuid",
-                    "example": "b50874ee-1a70-436e-ba24-572078895982"
                 },
                 "rent_fee": {
                     "type": "integer",
@@ -6796,10 +6925,6 @@
                 "slug": {
                     "type": "string",
                     "example": "unit-101-abcde1876drkjy"
-                },
-                "status": {
-                    "type": "string",
-                    "example": "Unit.Status.Available"
                 },
                 "tags": {
                     "type": "array",
@@ -6814,11 +6939,6 @@
                 "type": {
                     "type": "string",
                     "example": "APARTMENT"
-                },
-                "updated_at": {
-                    "type": "string",
-                    "format": "date-time",
-                    "example": "2023-01-01T00:00:00Z"
                 }
             }
         }

--- a/services/main/docs/swagger.yaml
+++ b/services/main/docs/swagger.yaml
@@ -896,6 +896,85 @@ definitions:
         example: 100
         type: integer
     type: object
+  transformations.AdminOutputUnit:
+    properties:
+      area:
+        example: 120.5
+        type: number
+      created_at:
+        example: "2023-01-01T00:00:00Z"
+        format: date-time
+        type: string
+      created_by:
+        $ref: '#/definitions/transformations.OutputClientUser'
+      created_by_id:
+        example: 1e81fea0-5e8b-4535-b449-1a2133e94a7a
+        format: uuid
+        type: string
+      description:
+        example: Spacious apartment with balcony
+        type: string
+      features:
+        additionalProperties: {}
+        type: object
+      id:
+        example: 4fce5dc8-8114-4ab2-a94b-b4536c27f43b
+        format: uuid
+        type: string
+      images:
+        example:
+        - http://www.images/unit101.jpg
+        items:
+          type: string
+        type: array
+      max_occupants_allowed:
+        example: 4
+        type: integer
+      name:
+        example: Unit 101
+        type: string
+      payment_frequency:
+        example: MONTHLY
+        type: string
+      property:
+        $ref: '#/definitions/transformations.OutputProperty'
+      property_block:
+        $ref: '#/definitions/transformations.OutputPropertyBlock'
+      property_block_id:
+        example: a12345ee-1a70-436e-ba24-572078895982
+        format: uuid
+        type: string
+      property_id:
+        example: b50874ee-1a70-436e-ba24-572078895982
+        format: uuid
+        type: string
+      rent_fee:
+        example: 1500
+        type: integer
+      rent_fee_currency:
+        example: USD
+        type: string
+      slug:
+        example: unit-101-abcde1876drkjy
+        type: string
+      status:
+        example: Unit.Status.Available
+        type: string
+      tags:
+        example:
+        - apartment
+        - balcony
+        items:
+          type: string
+        type: array
+      type:
+        example: APARTMENT
+        type: string
+      updated_at:
+        example: "2023-01-01T00:00:00Z"
+        format: date-time
+        type: string
+    type: object
   transformations.OutputAdmin:
     properties:
       created_at:
@@ -1482,16 +1561,6 @@ definitions:
       area:
         example: 120.5
         type: number
-      created_at:
-        example: "2023-01-01T00:00:00Z"
-        format: date-time
-        type: string
-      created_by:
-        $ref: '#/definitions/transformations.OutputClientUser'
-      created_by_id:
-        example: 1e81fea0-5e8b-4535-b449-1a2133e94a7a
-        format: uuid
-        type: string
       description:
         example: Spacious apartment with balcony
         type: string
@@ -1508,26 +1577,11 @@ definitions:
         items:
           type: string
         type: array
-      max_occupants_allowed:
-        example: 4
-        type: integer
       name:
         example: Unit 101
         type: string
       payment_frequency:
         example: MONTHLY
-        type: string
-      property:
-        $ref: '#/definitions/transformations.OutputProperty'
-      property_block:
-        $ref: '#/definitions/transformations.OutputPropertyBlock'
-      property_block_id:
-        example: a12345ee-1a70-436e-ba24-572078895982
-        format: uuid
-        type: string
-      property_id:
-        example: b50874ee-1a70-436e-ba24-572078895982
-        format: uuid
         type: string
       rent_fee:
         example: 1500
@@ -1538,9 +1592,6 @@ definitions:
       slug:
         example: unit-101-abcde1876drkjy
         type: string
-      status:
-        example: Unit.Status.Available
-        type: string
       tags:
         example:
         - apartment
@@ -1550,10 +1601,6 @@ definitions:
         type: array
       type:
         example: APARTMENT
-        type: string
-      updated_at:
-        example: "2023-01-01T00:00:00Z"
-        format: date-time
         type: string
     type: object
 info:
@@ -3610,7 +3657,7 @@ paths:
           schema:
             properties:
               data:
-                $ref: '#/definitions/transformations.OutputUnit'
+                $ref: '#/definitions/transformations.AdminOutputUnit'
             type: object
         "400":
           description: Error occurred when creating a unit
@@ -3813,7 +3860,7 @@ paths:
                     $ref: '#/definitions/lib.HTTPReturnPaginatedMetaResponse'
                   rows:
                     items:
-                      $ref: '#/definitions/transformations.OutputUnit'
+                      $ref: '#/definitions/transformations.AdminOutputUnit'
                     type: array
                 type: object
             type: object
@@ -3909,7 +3956,7 @@ paths:
           schema:
             properties:
               data:
-                $ref: '#/definitions/transformations.OutputUnit'
+                $ref: '#/definitions/transformations.AdminOutputUnit'
             type: object
         "400":
           description: Error occurred when fetching a unit
@@ -3961,7 +4008,7 @@ paths:
           schema:
             properties:
               data:
-                $ref: '#/definitions/transformations.OutputUnit'
+                $ref: '#/definitions/transformations.AdminOutputUnit'
             type: object
         "400":
           description: Error occurred when updating a unit
@@ -4598,6 +4645,42 @@ paths:
       summary: Sends a tenant invite to a possible tenant
       tags:
       - TenantApplication
+  /api/v1/units/{unit_id}:
+    get:
+      consumes:
+      - application/json
+      description: Fetch unit subset
+      parameters:
+      - description: Unit ID
+        in: path
+        name: unit_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            properties:
+              data:
+                $ref: '#/definitions/transformations.OutputUnit'
+            type: object
+        "400":
+          description: Error occurred when fetching a unit
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "404":
+          description: Unit not found
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "500":
+          description: An unexpected error occurred
+          schema:
+            type: string
+      summary: Fetch unit subset
+      tags:
+      - Units
 securityDefinitions:
   BearerAuth:
     description: Type "Bearer" followed by a space and JWT token.

--- a/services/main/internal/router/client-user.go
+++ b/services/main/internal/router/client-user.go
@@ -19,6 +19,7 @@ func NewClientUserRouter(appCtx pkg.AppContext, handlers handlers.Handlers) func
 				"/v1/client-users/forgot-password",
 				handlers.ClientUserHandler.SendForgotPasswordResetLink,
 			)
+			r.Get("/v1/units/{unit_id}", handlers.UnitHandler.FetchClientUnit)
 		})
 
 		// protected client user routes

--- a/services/main/internal/transformations/unit.go
+++ b/services/main/internal/transformations/unit.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gofrs/uuid"
 )
 
-type OutputUnit struct {
+type AdminOutputUnit struct {
 	ID                  string              `json:"id"                    example:"4fce5dc8-8114-4ab2-a94b-b4536c27f43b" format:"uuid"      description:"Unique identifier for the unit"`
 	Slug                string              `json:"slug"                  example:"unit-101-abcde1876drkjy"                                 description:"Slug for the unit"`
 	Name                string              `json:"name"                  example:"Unit 101"                                                description:"Name of the unit"`
@@ -32,7 +32,7 @@ type OutputUnit struct {
 	UpdatedAt           time.Time           `json:"updated_at"            example:"2023-01-01T00:00:00Z"                 format:"date-time" description:"Timestamp when the unit was last updated"`
 }
 
-func DBUnitToRest(i *models.Unit) any {
+func DBAdminUnitToRest(i *models.Unit) any {
 	if i == nil || i.ID == uuid.Nil {
 		return nil
 	}
@@ -60,6 +60,43 @@ func DBUnitToRest(i *models.Unit) any {
 		"created_by":            DBClientUserToRest(&i.CreatedBy),
 		"created_at":            i.CreatedAt,
 		"updated_at":            i.UpdatedAt,
+	}
+	return data
+}
+
+type OutputUnit struct {
+	ID               string         `json:"id"                example:"4fce5dc8-8114-4ab2-a94b-b4536c27f43b" format:"uuid" description:"Unique identifier for the unit"`
+	Slug             string         `json:"slug"              example:"unit-101-abcde1876drkjy"                            description:"Slug for the unit"`
+	Name             string         `json:"name"              example:"Unit 101"                                           description:"Name of the unit"`
+	Description      *string        `json:"description"       example:"Spacious apartment with balcony"                    description:"Optional description of the unit"`
+	Images           []string       `json:"images"            example:"http://www.images/unit101.jpg"                      description:"List of image URLs for the unit"`
+	Tags             []string       `json:"tags"              example:"apartment,balcony"                                  description:"Tags associated with the unit"`
+	Type             string         `json:"type"              example:"APARTMENT"                                          description:"Type of the unit (e.g., APARTMENT, HOUSE, STUDIO, OFFICE, RETAIL)"`
+	Area             *float64       `json:"area"              example:"120.5"                                              description:"Area of the unit in square feet or square meters"`
+	RentFee          int64          `json:"rent_fee"          example:"1500"                                               description:"Monthly rent amount"`
+	RentFeeCurrency  string         `json:"rent_fee_currency" example:"USD"                                                description:"Currency for the rent fee"`
+	PaymentFrequency string         `json:"payment_frequency" example:"MONTHLY"                                            description:"Payment frequency (e.g., WEEKLY, DAILY, MONTHLY, Quarterly, BiAnnually, Annually)"`
+	Features         map[string]any `json:"features"                                                                       description:"Additional metadata in JSON format"`
+}
+
+func DBUnitToRest(i *models.Unit) any {
+	if i == nil || i.ID == uuid.Nil {
+		return nil
+	}
+
+	data := map[string]any{
+		"id":                i.ID.String(),
+		"slug":              i.Slug,
+		"name":              i.Name,
+		"description":       i.Description,
+		"images":            i.Images,
+		"tags":              i.Tags,
+		"type":              i.Type,
+		"area":              i.Area,
+		"rent_fee":          i.RentFee,
+		"rent_fee_currency": i.RentFeeCurrency,
+		"payment_frequency": i.PaymentFrequency,
+		"features":          i.Features,
 	}
 	return data
 }


### PR DESCRIPTION
## PR Name or Description

Add unauthorized endpoint to fetch unit subset and refactor admin unit output

## Overview

This PR introduces a new public endpoint for fetching a subset of unit data for client users and refactors the admin unit output structure. It also updates OpenAPI documentation and related transformation logic.

## Detailed Technical Change

- Added `FetchClientUnit` handler in `internal/handlers/unit.go` to serve `/api/v1/units/{unit_id}` for client users.
- Registered the new route in `internal/router/client-user.go`.
- Refactored `OutputUnit` to `AdminOutputUnit` and introduced a new `OutputUnit` struct in `internal/transformations/unit.go`.
- Updated transformation functions: `DBAdminUnitToRest` and `DBUnitToRest`.
- Updated all admin-related endpoints and documentation to use `AdminOutputUnit`.
- Updated OpenAPI/Swagger docs (`docs.go`, `swagger.json`, `swagger.yaml`) to reflect the new and updated schemas and endpoints.

## Testing Approach

- Manual testing of the new `/api/v1/units/{unit_id}` endpoint to ensure correct data is returned for client users.
- Verified that admin endpoints return the updated `AdminOutputUnit` structure.
- Confirmed OpenAPI documentation renders the new and updated schemas and endpoints correctly.

## Result

<img width="1445" height="1004" alt="Screenshot 2026-01-13 at 5 22 56 PM" src="https://github.com/user-attachments/assets/ea6bb824-b82b-49a6-95e7-9111f1b10879" />

## Related Work

N/A

## Documentation

OpenAPI/Swagger documentation updated to reflect all changes.