### PR TITLE
Add endpoint to get tenant by phone and OutputTenant transformation

### DIFF
--- a/services/main/docs/docs.go
+++ b/services/main/docs/docs.go
@@ -5050,6 +5050,67 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/tenants/phone/{phone}": {
+            "get": {
+                "description": "Get tenant by phone",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Tenants"
+                ],
+                "summary": "Get tenant by phone",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Phone",
+                        "name": "phone",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "$ref": "#/definitions/transformations.OutputTenant"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Error occurred when fetching a tenant",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Tenant not found",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "422": {
+                        "description": "Invalid phone number",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "An unexpected error occurred",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/units/{unit_id}": {
             "get": {
                 "description": "Fetch unit subset",
@@ -7034,6 +7095,99 @@ const docTemplate = `{
                     "type": "string",
                     "format": "date-time",
                     "example": "2023-01-01T00:00:00Z"
+                }
+            }
+        },
+        "transformations.OutputTenant": {
+            "type": "object",
+            "properties": {
+                "date_of_birth": {
+                    "type": "string",
+                    "example": "1990-01-01"
+                },
+                "email": {
+                    "type": "string",
+                    "example": "john.doe@example.com"
+                },
+                "emergency_contact_name": {
+                    "type": "string",
+                    "example": "Mary Doe"
+                },
+                "emergency_contact_phone": {
+                    "type": "string",
+                    "example": "+1122334455"
+                },
+                "employer": {
+                    "type": "string",
+                    "example": "Tech Ltd."
+                },
+                "first_name": {
+                    "type": "string",
+                    "example": "John"
+                },
+                "gender": {
+                    "type": "string",
+                    "example": "male"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "4fce5dc8-8114-4ab2-a94b-b4536c27f43b"
+                },
+                "id_back_url": {
+                    "type": "string",
+                    "example": "https://example.com/id-back.jpg"
+                },
+                "id_front_url": {
+                    "type": "string",
+                    "example": "https://example.com/id-front.jpg"
+                },
+                "id_number": {
+                    "type": "string",
+                    "example": "ID123456"
+                },
+                "id_type": {
+                    "type": "string",
+                    "example": "ghana_card"
+                },
+                "last_name": {
+                    "type": "string",
+                    "example": "Doe"
+                },
+                "marital_status": {
+                    "type": "string",
+                    "example": "single"
+                },
+                "nationality": {
+                    "type": "string",
+                    "example": "Ghanaian"
+                },
+                "occupation": {
+                    "type": "string",
+                    "example": "Software Engineer"
+                },
+                "occupation_address": {
+                    "type": "string",
+                    "example": "456 Tech Ave, Accra"
+                },
+                "other_names": {
+                    "type": "string",
+                    "example": "Michael"
+                },
+                "phone": {
+                    "type": "string",
+                    "example": "+1234567890"
+                },
+                "profile_photo_url": {
+                    "type": "string",
+                    "example": "https://example.com/photo.jpg"
+                },
+                "proof_of_income_url": {
+                    "type": "string",
+                    "example": "https://example.com/income.pdf"
+                },
+                "relationship_to_emergency_contact": {
+                    "type": "string",
+                    "example": "sister"
                 }
             }
         },

--- a/services/main/docs/swagger.json
+++ b/services/main/docs/swagger.json
@@ -5042,6 +5042,67 @@
                 }
             }
         },
+        "/api/v1/tenants/phone/{phone}": {
+            "get": {
+                "description": "Get tenant by phone",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Tenants"
+                ],
+                "summary": "Get tenant by phone",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Phone",
+                        "name": "phone",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "$ref": "#/definitions/transformations.OutputTenant"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Error occurred when fetching a tenant",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Tenant not found",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "422": {
+                        "description": "Invalid phone number",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "An unexpected error occurred",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/units/{unit_id}": {
             "get": {
                 "description": "Fetch unit subset",
@@ -7026,6 +7087,99 @@
                     "type": "string",
                     "format": "date-time",
                     "example": "2023-01-01T00:00:00Z"
+                }
+            }
+        },
+        "transformations.OutputTenant": {
+            "type": "object",
+            "properties": {
+                "date_of_birth": {
+                    "type": "string",
+                    "example": "1990-01-01"
+                },
+                "email": {
+                    "type": "string",
+                    "example": "john.doe@example.com"
+                },
+                "emergency_contact_name": {
+                    "type": "string",
+                    "example": "Mary Doe"
+                },
+                "emergency_contact_phone": {
+                    "type": "string",
+                    "example": "+1122334455"
+                },
+                "employer": {
+                    "type": "string",
+                    "example": "Tech Ltd."
+                },
+                "first_name": {
+                    "type": "string",
+                    "example": "John"
+                },
+                "gender": {
+                    "type": "string",
+                    "example": "male"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "4fce5dc8-8114-4ab2-a94b-b4536c27f43b"
+                },
+                "id_back_url": {
+                    "type": "string",
+                    "example": "https://example.com/id-back.jpg"
+                },
+                "id_front_url": {
+                    "type": "string",
+                    "example": "https://example.com/id-front.jpg"
+                },
+                "id_number": {
+                    "type": "string",
+                    "example": "ID123456"
+                },
+                "id_type": {
+                    "type": "string",
+                    "example": "ghana_card"
+                },
+                "last_name": {
+                    "type": "string",
+                    "example": "Doe"
+                },
+                "marital_status": {
+                    "type": "string",
+                    "example": "single"
+                },
+                "nationality": {
+                    "type": "string",
+                    "example": "Ghanaian"
+                },
+                "occupation": {
+                    "type": "string",
+                    "example": "Software Engineer"
+                },
+                "occupation_address": {
+                    "type": "string",
+                    "example": "456 Tech Ave, Accra"
+                },
+                "other_names": {
+                    "type": "string",
+                    "example": "Michael"
+                },
+                "phone": {
+                    "type": "string",
+                    "example": "+1234567890"
+                },
+                "profile_photo_url": {
+                    "type": "string",
+                    "example": "https://example.com/photo.jpg"
+                },
+                "proof_of_income_url": {
+                    "type": "string",
+                    "example": "https://example.com/income.pdf"
+                },
+                "relationship_to_emergency_contact": {
+                    "type": "string",
+                    "example": "sister"
                 }
             }
         },

--- a/services/main/docs/swagger.yaml
+++ b/services/main/docs/swagger.yaml
@@ -1424,6 +1424,75 @@ definitions:
         format: date-time
         type: string
     type: object
+  transformations.OutputTenant:
+    properties:
+      date_of_birth:
+        example: "1990-01-01"
+        type: string
+      email:
+        example: john.doe@example.com
+        type: string
+      emergency_contact_name:
+        example: Mary Doe
+        type: string
+      emergency_contact_phone:
+        example: "+1122334455"
+        type: string
+      employer:
+        example: Tech Ltd.
+        type: string
+      first_name:
+        example: John
+        type: string
+      gender:
+        example: male
+        type: string
+      id:
+        example: 4fce5dc8-8114-4ab2-a94b-b4536c27f43b
+        type: string
+      id_back_url:
+        example: https://example.com/id-back.jpg
+        type: string
+      id_front_url:
+        example: https://example.com/id-front.jpg
+        type: string
+      id_number:
+        example: ID123456
+        type: string
+      id_type:
+        example: ghana_card
+        type: string
+      last_name:
+        example: Doe
+        type: string
+      marital_status:
+        example: single
+        type: string
+      nationality:
+        example: Ghanaian
+        type: string
+      occupation:
+        example: Software Engineer
+        type: string
+      occupation_address:
+        example: 456 Tech Ave, Accra
+        type: string
+      other_names:
+        example: Michael
+        type: string
+      phone:
+        example: "+1234567890"
+        type: string
+      profile_photo_url:
+        example: https://example.com/photo.jpg
+        type: string
+      proof_of_income_url:
+        example: https://example.com/income.pdf
+        type: string
+      relationship_to_emergency_contact:
+        example: sister
+        type: string
+    type: object
   transformations.OutputTenantApplication:
     properties:
       cancelled_at:
@@ -4918,6 +4987,46 @@ paths:
       summary: Sends a tenant invite to a possible tenant
       tags:
       - TenantApplication
+  /api/v1/tenants/phone/{phone}:
+    get:
+      consumes:
+      - application/json
+      description: Get tenant by phone
+      parameters:
+      - description: Phone
+        in: path
+        name: phone
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            properties:
+              data:
+                $ref: '#/definitions/transformations.OutputTenant'
+            type: object
+        "400":
+          description: Error occurred when fetching a tenant
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "404":
+          description: Tenant not found
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "422":
+          description: Invalid phone number
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "500":
+          description: An unexpected error occurred
+          schema:
+            type: string
+      summary: Get tenant by phone
+      tags:
+      - Tenants
   /api/v1/units/{unit_id}:
     get:
       consumes:

--- a/services/main/internal/handlers/main.go
+++ b/services/main/internal/handlers/main.go
@@ -15,6 +15,7 @@ type Handlers struct {
 	PropertyBlockHandler      PropertyBlockHandler
 	UnitHandler               UnitHandler
 	TenantApplicationHandler  TenantApplicationHandler
+	TenantHandler             TenantHandler
 }
 
 func NewHandlers(appCtx pkg.AppContext, services services.Services) Handlers {
@@ -27,6 +28,7 @@ func NewHandlers(appCtx pkg.AppContext, services services.Services) Handlers {
 	propertyBlockHandler := NewPropertyBlockHandler(appCtx, services.PropertyBlockService)
 	unitHandler := NewUnitHandler(appCtx, services.UnitService)
 	tenantApplicationHandler := NewTenantApplicationHandler(appCtx, services.TenantApplicationService)
+	tenantHandler := NewTenantHandler(appCtx, services.TenantService)
 
 	return Handlers{
 		ClientApplicationHandler:  clientApplicationHandler,
@@ -38,5 +40,6 @@ func NewHandlers(appCtx pkg.AppContext, services services.Services) Handlers {
 		PropertyBlockHandler:      propertyBlockHandler,
 		UnitHandler:               unitHandler,
 		TenantApplicationHandler:  tenantApplicationHandler,
+		TenantHandler:             tenantHandler,
 	}
 }

--- a/services/main/internal/handlers/tenant.go
+++ b/services/main/internal/handlers/tenant.go
@@ -1,0 +1,54 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+
+	"github.com/Bendomey/rent-loop/services/main/internal/services"
+	"github.com/Bendomey/rent-loop/services/main/internal/transformations"
+	"github.com/Bendomey/rent-loop/services/main/pkg"
+	"github.com/go-chi/chi/v5"
+)
+
+type TenantHandler struct {
+	appCtx  pkg.AppContext
+	service services.TenantService
+}
+
+func NewTenantHandler(appCtx pkg.AppContext, service services.TenantService) TenantHandler {
+	return TenantHandler{appCtx, service}
+}
+
+// GetTenantByPhone godoc
+//
+//	@Summary		Get tenant by phone
+//	@Description	Get tenant by phone
+//	@Tags			Tenants
+//	@Accept			json
+//	@Produce		json
+//	@Param			phone	path		string	true	"Phone"
+//	@Success		200		{object}	object{data=transformations.OutputTenant}
+//	@Failure		400		{object}	lib.HTTPError	"Error occurred when fetching a tenant"
+//	@Failure		422		{object}	lib.HTTPError	"Invalid phone number"
+//	@Failure		404		{object}	lib.HTTPError	"Tenant not found"
+//	@Failure		500		{object}	string			"An unexpected error occurred"
+//	@Router			/api/v1/tenants/phone/{phone} [get]
+func (h *TenantHandler) GetTenantByPhone(w http.ResponseWriter, r *http.Request) {
+	rawPhone := chi.URLParam(r, "phone")
+	phone, err := url.PathUnescape(rawPhone)
+	if err != nil {
+		http.Error(w, "Invalid phone number", http.StatusUnprocessableEntity)
+		return
+	}
+
+	tenant, getTenantErr := h.service.GetTenantByPhone(r.Context(), phone)
+	if getTenantErr != nil {
+		HandleErrorResponse(w, getTenantErr)
+		return
+	}
+
+	json.NewEncoder(w).Encode(map[string]any{
+		"data": transformations.DBTenantToRest(tenant),
+	})
+}

--- a/services/main/internal/router/tenant.go
+++ b/services/main/internal/router/tenant.go
@@ -12,6 +12,7 @@ func NewTenantAccountRouter(appCtx pkg.AppContext, handlers handlers.Handlers) f
 		// unprotected tenant user routes
 		r.Group(func(r chi.Router) {
 			r.Post("/v1/tenant-applications", handlers.TenantApplicationHandler.CreateTenantApplication)
+			r.Get("/v1/tenants/phone/{phone}", handlers.TenantHandler.GetTenantByPhone)
 		})
 
 		// protected tenant user routes

--- a/services/main/internal/transformations/tenant.go
+++ b/services/main/internal/transformations/tenant.go
@@ -1,0 +1,115 @@
+package transformations
+
+import (
+	"time"
+
+	"github.com/Bendomey/rent-loop/services/main/internal/models"
+	"github.com/gofrs/uuid"
+)
+
+type OutputTenant struct {
+	ID              string    `json:"id"                          example:"4fce5dc8-8114-4ab2-a94b-b4536c27f43b"`
+	FirstName       string    `json:"first_name"                  example:"John"`
+	OtherNames      *string   `json:"other_names,omitempty"       example:"Michael"`
+	LastName        string    `json:"last_name"                   example:"Doe"`
+	Email           *string   `json:"email,omitempty"             example:"john.doe@example.com"`
+	Phone           string    `json:"phone"                       example:"+1234567890"`
+	Gender          string    `json:"gender"                      example:"male"`
+	DateOfBirth     time.Time `json:"date_of_birth"               example:"1990-01-01"`
+	Nationality     string    `json:"nationality"                 example:"Ghanaian"`
+	MaritalStatus   string    `json:"marital_status"              example:"single"`
+	ProfilePhotoUrl *string   `json:"profile_photo_url,omitempty" example:"https://example.com/photo.jpg"`
+	IDType          string    `json:"id_type"                     example:"ghana_card"`
+	IDNumber        string    `json:"id_number"                   example:"ID123456"`
+	IDFrontUrl      *string   `json:"id_front_url,omitempty"      example:"https://example.com/id-front.jpg"`
+	IDBackUrl       *string   `json:"id_back_url,omitempty"       example:"https://example.com/id-back.jpg"`
+
+	EmergencyContactName           string `json:"emergency_contact_name"            example:"Mary Doe"`
+	EmergencyContactPhone          string `json:"emergency_contact_phone"           example:"+1122334455"`
+	RelationshipToEmergencyContact string `json:"relationship_to_emergency_contact" example:"sister"`
+
+	Occupation        string  `json:"occupation"                    example:"Software Engineer"`
+	Employer          string  `json:"employer"                      example:"Tech Ltd."`
+	OccupationAddress string  `json:"occupation_address"            example:"456 Tech Ave, Accra"`
+	ProofOfIncomeUrl  *string `json:"proof_of_income_url,omitempty" example:"https://example.com/income.pdf"`
+}
+
+type OutputAdminTenant struct {
+	OutputTenant
+
+	CreatedById *string           `json:"created_by_id,omitempty" example:"72432ce6-5620-4ecf-a862-4bf2140556a"`
+	CreatedBy   *OutputClientUser `json:"created_by,omitempty"`
+
+	CreatedAt time.Time `json:"created_at" example:"2024-06-01T09:00:00Z"`
+	UpdatedAt time.Time `json:"updated_at" example:"2024-06-10T09:00:00Z"`
+}
+
+func DBAdminTenantToRest(i *models.Tenant) any {
+	if i == nil || i.ID == uuid.Nil {
+		return nil
+	}
+
+	data := map[string]any{
+		"id":                                i.ID,
+		"first_name":                        i.FirstName,
+		"other_names":                       i.OtherNames,
+		"last_name":                         i.LastName,
+		"email":                             i.Email,
+		"phone":                             i.Phone,
+		"gender":                            i.Gender,
+		"date_of_birth":                     i.DateOfBirth,
+		"nationality":                       i.Nationality,
+		"marital_status":                    i.MaritalStatus,
+		"profile_photo_url":                 i.ProfilePhotoUrl,
+		"id_type":                           i.IDType,
+		"id_number":                         i.IDNumber,
+		"id_front_url":                      i.IDFrontUrl,
+		"id_back_url":                       i.IDBackUrl,
+		"emergency_contact_name":            i.EmergencyContactName,
+		"emergency_contact_phone":           i.EmergencyContactPhone,
+		"relationship_to_emergency_contact": i.RelationshipToEmergencyContact,
+		"occupation":                        i.Occupation,
+		"employer":                          i.Employer,
+		"occupation_address":                i.OccupationAddress,
+		"proof_of_income_url":               i.ProofOfIncomeUrl,
+		"created_by_id":                     i.CreatedById,
+		"created_by":                        DBClientUserToRest(&i.CreatedBy),
+		"created_at":                        i.CreatedAt,
+		"updated_at":                        i.UpdatedAt,
+	}
+
+	return data
+}
+
+func DBTenantToRest(i *models.Tenant) any {
+	if i == nil || i.ID == uuid.Nil {
+		return nil
+	}
+
+	data := map[string]any{
+		"id":                                i.ID,
+		"first_name":                        i.FirstName,
+		"other_names":                       i.OtherNames,
+		"last_name":                         i.LastName,
+		"email":                             i.Email,
+		"phone":                             i.Phone,
+		"gender":                            i.Gender,
+		"date_of_birth":                     i.DateOfBirth,
+		"nationality":                       i.Nationality,
+		"marital_status":                    i.MaritalStatus,
+		"profile_photo_url":                 i.ProfilePhotoUrl,
+		"id_type":                           i.IDType,
+		"id_number":                         i.IDNumber,
+		"id_front_url":                      i.IDFrontUrl,
+		"id_back_url":                       i.IDBackUrl,
+		"emergency_contact_name":            i.EmergencyContactName,
+		"emergency_contact_phone":           i.EmergencyContactPhone,
+		"relationship_to_emergency_contact": i.RelationshipToEmergencyContact,
+		"occupation":                        i.Occupation,
+		"employer":                          i.Employer,
+		"occupation_address":                i.OccupationAddress,
+		"proof_of_income_url":               i.ProofOfIncomeUrl,
+	}
+
+	return data
+}


### PR DESCRIPTION
## PR Name or Description

Add endpoint to get tenant by phone and OutputTenant transformation

## Overview

This PR introduces a new API endpoint to fetch a tenant by their phone number. It also adds the OutputTenant transformation struct and related logic for consistent API responses.

## Detailed Technical Change

- Added `GetTenantByPhone` method to `TenantService` and its implementation.
- Created `TenantHandler` with a `GetTenantByPhone` handler function.
- Registered the new handler in the router (`/api/v1/tenants/phone/{phone}`).
- Added `OutputTenant` and `OutputAdminTenant` structs in `internal/transformations/tenant.go` with transformation functions.
- Updated OpenAPI/Swagger documentation to reflect the new endpoint and response schema.

## Testing Approach & Result

- Manually tested the new endpoint using HTTP requests to ensure correct tenant retrieval by phone.
- Verified error handling for invalid and non-existent phone numbers.
- Confirmed that the OpenAPI docs generate the correct schema for the new endpoint.

## Result

<img width="1448" height="1004" alt="Screenshot 2026-01-27 at 10 02 30 AM" src="https://github.com/user-attachments/assets/62573982-eda5-47d2-b0bf-cc624e9921e4" />

## Related Work

N/A

## Documentation

OpenAPI/Swagger documentation updated for the new endpoint and response schema.