### PR TITLE
Add GET Lease by ID endpoint with populate support

### DIFF
--- a/services/main/docs/docs.go
+++ b/services/main/docs/docs.go
@@ -2352,6 +2352,79 @@ const docTemplate = `{
             }
         },
         "/api/v1/leases/{lease_id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get lease",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Lease"
+                ],
+                "summary": "Get lease",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Lease ID",
+                        "name": "lease_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "name": "populate",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Lease",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "$ref": "#/definitions/transformations.OutputAdminLease"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Error occurred when getting lease",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid or absent authentication token",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Lease not found",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "An unexpected error occurred",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
             "patch": {
                 "security": [
                     {

--- a/services/main/docs/swagger.json
+++ b/services/main/docs/swagger.json
@@ -2344,6 +2344,79 @@
             }
         },
         "/api/v1/leases/{lease_id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get lease",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Lease"
+                ],
+                "summary": "Get lease",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Lease ID",
+                        "name": "lease_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "name": "populate",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Lease",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "$ref": "#/definitions/transformations.OutputAdminLease"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Error occurred when getting lease",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid or absent authentication token",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Lease not found",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "An unexpected error occurred",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
             "patch": {
                 "security": [
                     {

--- a/services/main/docs/swagger.yaml
+++ b/services/main/docs/swagger.yaml
@@ -3366,6 +3366,53 @@ paths:
       tags:
       - Documents
   /api/v1/leases/{lease_id}:
+    get:
+      consumes:
+      - application/json
+      description: Get lease
+      parameters:
+      - description: Lease ID
+        in: path
+        name: lease_id
+        required: true
+        type: string
+      - collectionFormat: csv
+        in: query
+        items:
+          type: string
+        name: populate
+        type: array
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Lease
+          schema:
+            properties:
+              data:
+                $ref: '#/definitions/transformations.OutputAdminLease'
+            type: object
+        "400":
+          description: Error occurred when getting lease
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "401":
+          description: Invalid or absent authentication token
+          schema:
+            type: string
+        "404":
+          description: Lease not found
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "500":
+          description: An unexpected error occurred
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Get lease
+      tags:
+      - Lease
     patch:
       consumes:
       - application/json

--- a/services/main/internal/router/client-user.go
+++ b/services/main/internal/router/client-user.go
@@ -150,6 +150,7 @@ func NewClientUserRouter(appCtx pkg.AppContext, handlers handlers.Handlers) func
 			})
 
 			r.Route("/v1/leases", func(r chi.Router) {
+				r.Get("/{lease_id}", handlers.LeaseHandler.GetLeaseByID)
 				r.With(middlewares.ValidateRoleClientUserMiddleware(appCtx, "ADMIN", "OWNER")).
 					Patch("/{lease_id}", handlers.LeaseHandler.UpdateLease)
 			})


### PR DESCRIPTION
## PR Name or Description

Add GET Lease by ID endpoint with populate support

## Overview

This pull request introduces a new API endpoint to retrieve a lease by its ID, with support for populating related fields. It updates the handler, service, repository, and documentation to support this functionality.

## Detailed Technical Change

- Added `GetLeaseByID` handler in `internal/handlers/lease.go` with corresponding Swagger documentation.
- Introduced `GetByIDWithPopulate` method in the lease service (`internal/services/lease.go`).
- Updated the router (`internal/router/client-user.go`) to register the new GET endpoint at `/api/v1/leases/{lease_id}`.
- Updated API documentation files: `docs.go`, `swagger.json`, and `swagger.yaml`.
- Added `GetLeaseQuery` struct for query parameter parsing.

## Testing Approach

- Manually tested the new endpoint using HTTP requests to ensure correct lease retrieval and population of related fields.
- Verified error handling for not found and server errors.
- Confirmed API documentation updates via Swagger UI.

## Result

<img width="1463" height="1005" alt="Screenshot 2026-01-30 at 2 11 24 PM" src="https://github.com/user-attachments/assets/cf2662b7-c253-428c-a476-d196944d2b54" />

## Related Work

N/A

## Documentation

API documentation updated in `docs.go`, `swagger.json`, and `swagger.yaml`.