### PR TITLE
Add Unit Status Field to OutputUnit and API Documentation

### DIFF
--- a/services/main/docs/docs.go
+++ b/services/main/docs/docs.go
@@ -8482,6 +8482,10 @@ const docTemplate = `{
                     "type": "string",
                     "example": "unit-101-abcde1876drkjy"
                 },
+                "status": {
+                    "type": "string",
+                    "example": "Unit.Status.Available"
+                },
                 "tags": {
                     "type": "array",
                     "items": {

--- a/services/main/docs/swagger.json
+++ b/services/main/docs/swagger.json
@@ -8474,6 +8474,10 @@
                     "type": "string",
                     "example": "unit-101-abcde1876drkjy"
                 },
+                "status": {
+                    "type": "string",
+                    "example": "Unit.Status.Available"
+                },
                 "tags": {
                     "type": "array",
                     "items": {

--- a/services/main/docs/swagger.yaml
+++ b/services/main/docs/swagger.yaml
@@ -1908,6 +1908,9 @@ definitions:
       slug:
         example: unit-101-abcde1876drkjy
         type: string
+      status:
+        example: Unit.Status.Available
+        type: string
       tags:
         example:
         - apartment

--- a/services/main/internal/transformations/unit.go
+++ b/services/main/internal/transformations/unit.go
@@ -77,11 +77,19 @@ type OutputUnit struct {
 	RentFeeCurrency  string         `json:"rent_fee_currency" example:"USD"                                                description:"Currency for the rent fee"`
 	PaymentFrequency string         `json:"payment_frequency" example:"MONTHLY"                                            description:"Payment frequency (e.g., WEEKLY, DAILY, MONTHLY, Quarterly, BiAnnually, Annually)"`
 	Features         map[string]any `json:"features"                                                                       description:"Additional metadata in JSON format"`
+	Status           string         `json:"status"            example:"Unit.Status.Available"                              description:"Current status of the unit (e.g., Unit.Status.Available Unit.Status.Unavailable)"`
 }
 
 func DBUnitToRest(i *models.Unit) any {
 	if i == nil || i.ID == uuid.Nil {
 		return nil
+	}
+
+	var status string
+	if i.Status == "Unit.Status.Available" {
+		status = "Unit.Status.Available"
+	} else {
+		status = "Unit.Status.Unavailable"
 	}
 
 	data := map[string]any{
@@ -97,6 +105,7 @@ func DBUnitToRest(i *models.Unit) any {
 		"rent_fee_currency": i.RentFeeCurrency,
 		"payment_frequency": i.PaymentFrequency,
 		"features":          i.Features,
+		"status":            status,
 	}
 	return data
 }


### PR DESCRIPTION
## PR Name or Description

Add Unit Status Field to OutputUnit and API Documentation

## Overview

This pull request introduces a new "status" field to the OutputUnit struct and updates the API documentation (Swagger and YAML) to reflect this addition. The status field indicates the current availability of a unit.

## Detailed Technical Change

- Added `Status` field to `OutputUnit` struct in `internal/transformations/unit.go`.
- Updated `DBUnitToRest` function to include logic for setting the status value based on the unit's availability.
- Modified API documentation files: `docs.go`, `swagger.json`, and `swagger.yaml` to include the new status field with example values.

## Testing Approach

- Verified that the status field is correctly populated in the API response.
- Confirmed that the documentation updates are reflected in Swagger UI.
- Manual inspection of API output and documentation files.

## Result

if unit is in any other status besides Available
<img width="1444" height="1004" alt="Screenshot 2026-02-10 at 9 54 25 PM" src="https://github.com/user-attachments/assets/5acbc9f4-5136-4228-806a-625c2a02fc11" />

if unit is of status available
<img width="1443" height="1004" alt="Screenshot 2026-02-10 at 9 54 37 PM" src="https://github.com/user-attachments/assets/d26f730f-a35a-48ff-b223-bd9e3c366200" />

## Related Work

N/A

## Documentation

Updated API documentation files (`docs.go`, `swagger.json`, `swagger.yaml`) to include the new status field.