### PR TITLE
Add Lease Cancellation Endpoint and Service Logic

### DIFF
--- a/services/main/docs/docs.go
+++ b/services/main/docs/docs.go
@@ -3270,6 +3270,79 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/leases/{lease_id}/status:cancelled": {
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Cancel lease",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Lease"
+                ],
+                "summary": "Cancel lease",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Lease ID",
+                        "name": "lease_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Cancel lease request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.CancelLeaseRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Lease Cancelled Successfully"
+                    },
+                    "400": {
+                        "description": "Error occurred when cancelling lease",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid or absent authentication token",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Lease not found",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "An unexpected error occurred",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/payment-accounts": {
             "get": {
                 "security": [
@@ -7239,6 +7312,15 @@ const docTemplate = `{
                 "phone": {
                     "type": "string",
                     "example": "+233281234569"
+                }
+            }
+        },
+        "handlers.CancelLeaseRequest": {
+            "type": "object",
+            "properties": {
+                "cancellation_reason": {
+                    "type": "string",
+                    "example": "Lease was cancelled due to a tenant's request."
                 }
             }
         },

--- a/services/main/docs/swagger.json
+++ b/services/main/docs/swagger.json
@@ -3262,6 +3262,79 @@
                 }
             }
         },
+        "/api/v1/leases/{lease_id}/status:cancelled": {
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Cancel lease",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Lease"
+                ],
+                "summary": "Cancel lease",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Lease ID",
+                        "name": "lease_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Cancel lease request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.CancelLeaseRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Lease Cancelled Successfully"
+                    },
+                    "400": {
+                        "description": "Error occurred when cancelling lease",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid or absent authentication token",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Lease not found",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error",
+                        "schema": {
+                            "$ref": "#/definitions/lib.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "An unexpected error occurred",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/payment-accounts": {
             "get": {
                 "security": [
@@ -7231,6 +7304,15 @@
                 "phone": {
                     "type": "string",
                     "example": "+233281234569"
+                }
+            }
+        },
+        "handlers.CancelLeaseRequest": {
+            "type": "object",
+            "properties": {
+                "cancellation_reason": {
+                    "type": "string",
+                    "example": "Lease was cancelled due to a tenant's request."
                 }
             }
         },

--- a/services/main/docs/swagger.yaml
+++ b/services/main/docs/swagger.yaml
@@ -57,6 +57,12 @@ definitions:
     required:
     - channel
     type: object
+  handlers.CancelLeaseRequest:
+    properties:
+      cancellation_reason:
+        example: Lease was cancelled due to a tenant's request.
+        type: string
+    type: object
   handlers.CancelTenantApplicationRequest:
     properties:
       reason:
@@ -4388,6 +4394,53 @@ paths:
       security:
       - BearerAuth: []
       summary: Activate lease
+      tags:
+      - Lease
+  /api/v1/leases/{lease_id}/status:cancelled:
+    patch:
+      consumes:
+      - application/json
+      description: Cancel lease
+      parameters:
+      - description: Lease ID
+        in: path
+        name: lease_id
+        required: true
+        type: string
+      - description: Cancel lease request body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.CancelLeaseRequest'
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: Lease Cancelled Successfully
+        "400":
+          description: Error occurred when cancelling lease
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "401":
+          description: Invalid or absent authentication token
+          schema:
+            type: string
+        "404":
+          description: Lease not found
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "422":
+          description: Validation error
+          schema:
+            $ref: '#/definitions/lib.HTTPError'
+        "500":
+          description: An unexpected error occurred
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Cancel lease
       tags:
       - Lease
   /api/v1/payment-accounts:

--- a/services/main/internal/router/client-user.go
+++ b/services/main/internal/router/client-user.go
@@ -162,6 +162,8 @@ func NewClientUserRouter(appCtx pkg.AppContext, handlers handlers.Handlers) func
 					Patch("/", handlers.LeaseHandler.UpdateLease)
 				r.With(middlewares.ValidateRoleClientUserMiddleware(appCtx, "ADMIN", "OWNER")).
 					Patch("/status:active", handlers.LeaseHandler.ActivateLease)
+				r.With(middlewares.ValidateRoleClientUserMiddleware(appCtx, "ADMIN", "OWNER")).
+					Patch("/status:cancelled", handlers.LeaseHandler.CancelLease)
 			})
 
 			r.Route("/v1/payment-accounts", func(r chi.Router) {


### PR DESCRIPTION
## PR Name or Description

Add Lease Cancellation Endpoint and Service Logic

## Overview

This pull request introduces a new API endpoint to allow cancellation of leases. It includes handler, service, and documentation updates to support lease cancellation with a reason.

## Detailed Technical Change

- Added `CancelLeaseRequest` struct and `CancelLease` handler in `internal/handlers/lease.go`.
- Implemented `CancelLease` method and `CancelLeaseInput` struct in `internal/services/lease.go`.
- Updated `LeaseService` interface.
- Registered the new endpoint in `internal/router/client-user.go`.
- Updated API documentation in `docs.go`, `swagger.json`, and `swagger.yaml`.

## Testing Approach

- Manual testing of the new PATCH `/api/v1/leases/{lease_id}/status:cancelled` endpoint with valid and invalid payloads.
- Verified correct status codes and error handling.
- Confirmed email and SMS notifications are triggered on cancellation.

## Result

<img width="1447" height="1004" alt="Screenshot 2026-02-12 at 5 12 49 PM" src="https://github.com/user-attachments/assets/e143c023-26b8-47a9-bdf2-f3abe2d0de86" />

## Related Work

N/A

## Documentation

API documentation updated in Swagger files.