### PR TITLE
feat: enhance maintenance request handling with asset support

### DIFF
--- a/apps/go/docs/changelog.md
+++ b/apps/go/docs/changelog.md
@@ -6,3 +6,9 @@
 - Modules present: auth, home, payments, maintenance, more (announcements, profile, lease details, unit details, application details, unit condition reports, delete account)
 - Notifiers: send_otp, verify_otp, create_maintenance_request, maintenance_requests (paginated), acknowledge_checklist, create_offline_payment, register_fcm_token
 - Providers: leases, invoices, announcements, checklists, unit, paymentAccounts, maintenanceRequest, maintenanceBadge, tenantApplication
+
+## 2026-08-01 — Maintenance requests: removed dead unit fields
+- API change (RENTL-48): a maintenance request now targets many assets (units and/or blocks), so it no longer carries a single `unit_id`/`unit`.
+- Removed `MaintenanceUnitModel`, and `unitId` / `unit` from `MaintenanceRequestModel`. Both fields were already unused — no maintenance screen in this app displayed the unit — and both were nullable, so the app kept working regardless. This is dead-code removal, not a fix.
+- No `assets` field was added: tenant-visible requests are always single-unit by design, and nothing here renders assets. Add it only when a screen needs it.
+- The maintenance API populate strings were unaffected (`ActivityLogs`, `Expenses`, `Expenses.Invoices` — this app never requested `Unit`).

--- a/apps/go/lib/src/repository/models/maintenance_request_model.dart
+++ b/apps/go/lib/src/repository/models/maintenance_request_model.dart
@@ -3,24 +3,6 @@ import 'invoice_model.dart';
 
 part 'maintenance_request_model.g.dart';
 
-@JsonSerializable()
-class MaintenanceUnitModel {
-  final String id;
-  final String name;
-  final String slug;
-
-  MaintenanceUnitModel({
-    required this.id,
-    required this.name,
-    required this.slug,
-  });
-
-  factory MaintenanceUnitModel.fromJson(Map<String, dynamic> json) =>
-      _$MaintenanceUnitModelFromJson(json);
-
-  Map<String, dynamic> toJson() => _$MaintenanceUnitModelToJson(this);
-}
-
 int? _amountFromJson(dynamic value) {
   if (value == null) return null;
   if (value is int) return value;
@@ -101,8 +83,6 @@ class MaintenanceRequestModel {
   final String? priority;
   final String? status;
   final String? code;
-  @JsonKey(name: 'unit_id')
-  final String? unitId;
   @JsonKey(name: 'lease_id')
   final String? leaseId;
   final List<String>? attachments;
@@ -118,7 +98,6 @@ class MaintenanceRequestModel {
   final String? canceledAt;
   @JsonKey(name: 'cancellation_reason')
   final String? cancellationReason;
-  final MaintenanceUnitModel? unit;
   @JsonKey(name: 'activity_logs')
   final List<MaintenanceActivityLogModel>? activityLogs;
   final List<MaintenanceExpenseModel>? expenses;
@@ -131,7 +110,6 @@ class MaintenanceRequestModel {
     this.priority,
     this.status,
     this.code,
-    this.unitId,
     this.leaseId,
     this.attachments,
     this.createdAt,
@@ -140,7 +118,6 @@ class MaintenanceRequestModel {
     this.startedAt,
     this.canceledAt,
     this.cancellationReason,
-    this.unit,
     this.activityLogs,
     this.expenses,
   });

--- a/apps/go/lib/src/repository/models/maintenance_request_model.g.dart
+++ b/apps/go/lib/src/repository/models/maintenance_request_model.g.dart
@@ -6,22 +6,6 @@ part of 'maintenance_request_model.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-MaintenanceUnitModel _$MaintenanceUnitModelFromJson(
-        Map<String, dynamic> json) =>
-    MaintenanceUnitModel(
-      id: json['id'] as String,
-      name: json['name'] as String,
-      slug: json['slug'] as String,
-    );
-
-Map<String, dynamic> _$MaintenanceUnitModelToJson(
-        MaintenanceUnitModel instance) =>
-    <String, dynamic>{
-      'id': instance.id,
-      'name': instance.name,
-      'slug': instance.slug,
-    };
-
 MaintenanceExpenseModel _$MaintenanceExpenseModelFromJson(
         Map<String, dynamic> json) =>
     MaintenanceExpenseModel(
@@ -86,7 +70,6 @@ MaintenanceRequestModel _$MaintenanceRequestModelFromJson(
       priority: json['priority'] as String?,
       status: json['status'] as String?,
       code: json['code'] as String?,
-      unitId: json['unit_id'] as String?,
       leaseId: json['lease_id'] as String?,
       attachments: (json['attachments'] as List<dynamic>?)
           ?.map((e) => e as String)
@@ -97,9 +80,6 @@ MaintenanceRequestModel _$MaintenanceRequestModelFromJson(
       startedAt: json['started_at'] as String?,
       canceledAt: json['canceled_at'] as String?,
       cancellationReason: json['cancellation_reason'] as String?,
-      unit: json['unit'] == null
-          ? null
-          : MaintenanceUnitModel.fromJson(json['unit'] as Map<String, dynamic>),
       activityLogs: (json['activity_logs'] as List<dynamic>?)
           ?.map((e) =>
               MaintenanceActivityLogModel.fromJson(e as Map<String, dynamic>))
@@ -120,7 +100,6 @@ Map<String, dynamic> _$MaintenanceRequestModelToJson(
       'priority': instance.priority,
       'status': instance.status,
       'code': instance.code,
-      'unit_id': instance.unitId,
       'lease_id': instance.leaseId,
       'attachments': instance.attachments,
       'created_at': instance.createdAt,
@@ -129,7 +108,6 @@ Map<String, dynamic> _$MaintenanceRequestModelToJson(
       'started_at': instance.startedAt,
       'canceled_at': instance.canceledAt,
       'cancellation_reason': instance.cancellationReason,
-      'unit': instance.unit,
       'activity_logs': instance.activityLogs,
       'expenses': instance.expenses,
     };

--- a/apps/pm_mobile/lib/src/api/maintenance_request_api.dart
+++ b/apps/pm_mobile/lib/src/api/maintenance_request_api.dart
@@ -24,7 +24,8 @@ class MaintenanceRequestApi extends AbstractApi {
   MaintenanceRequestApi({required super.tokenManager});
 
   static const _populate =
-      'Unit,AssignedWorker,AssignedWorker.User,AssignedManager,AssignedManager.User';
+      'Assets,Assets.Unit,Assets.PropertyBlock,AssignedWorker,'
+      'AssignedWorker.User,AssignedManager,AssignedManager.User';
 
   /// `GET .../maintenance-requests` — the cross-property "mobile" route
   /// (`ListAcrossProperties` on the backend), built specifically for an
@@ -94,7 +95,8 @@ class MaintenanceRequestApi extends AbstractApi {
   /// creator paths (absent from the board's [_populate]) drive the "opened
   /// by" attribution the detail hero shows.
   static const _detailPopulate =
-      'Unit,AssignedWorker,AssignedWorker.User,AssignedManager,'
+      'Assets,Assets.Unit,Assets.PropertyBlock,AssignedWorker,'
+      'AssignedWorker.User,AssignedManager,'
       'AssignedManager.User,CreatedByTenant,CreatedByClientUser.User';
 
   /// `GET .../properties/{propertyId}/maintenance-requests/{requestId}` — the
@@ -215,9 +217,9 @@ class MaintenanceRequestApi extends AbstractApi {
   /// `PATCH .../properties/{propertyId}/maintenance-requests/{requestId}/status`
   /// — this is a per-property route (unlike the cross-property list above),
   /// matching web's `useUpdateMaintenanceRequestStatus`. [propertyId] comes
-  /// from the request's own `unit.propertyId` (populated via the `Unit`
-  /// populate path above, backed by the backend fix that makes `property_id`
-  /// present on that nested object).
+  /// from the request's own `propertyId`, which the API returns directly — a
+  /// request can target several units and blocks, so there is no single nested
+  /// unit to read it from.
   Future<void> updateStatus({
     required String clientId,
     required String propertyId,

--- a/apps/pm_mobile/lib/src/modules/main/activity/maintenance_board.dart
+++ b/apps/pm_mobile/lib/src/modules/main/activity/maintenance_board.dart
@@ -83,7 +83,7 @@ class _MaintCard extends StatelessWidget {
           if (context.mounted) {
             context.push(
               '/activity/maintenances/${m.id}',
-              extra: m.unit?.propertyId,
+              extra: m.propertyId,
             );
           }
         },
@@ -159,7 +159,7 @@ class _CardBody extends StatelessWidget {
           ),
           const SizedBox(height: 4),
           Text(
-            m.unit?.name ?? '—',
+            m.assetSummary,
             style: const TextStyle(
               fontFamily: RLTokens.fontSans,
               fontSize: 12.5,
@@ -667,8 +667,7 @@ class _MaintenanceBoardState extends ConsumerState<MaintenanceBoard> {
     for (final status in kMaintenanceStatusOrder) {
       final state = ref.read(maintenanceRequestsNotifierProvider(status));
       for (final item in state.items) {
-        final propertyId = item.unit?.propertyId;
-        if (propertyId != null) propertyIds.add(propertyId);
+        propertyIds.add(item.propertyId);
       }
     }
     if (propertyIds.isNotEmpty) {

--- a/apps/pm_mobile/lib/src/modules/main/activity/maintenance_detail.dart
+++ b/apps/pm_mobile/lib/src/modules/main/activity/maintenance_detail.dart
@@ -566,12 +566,14 @@ class _PropertiesCard extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final priority = mrPriorityLabelFromApi(request.priority);
-    // Both destinations are property-scoped routes, so neither link can be
-    // offered without the unit's property id.
-    final propertyId = request.unit?.propertyId;
+    // The request carries its own property, so property-scoped links no longer
+    // depend on a unit being populated. A block-only request has no units at
+    // all and must still render.
+    final propertyId = request.propertyId;
     final leaseId = request.leaseId;
-    final canOpenUnit = propertyId != null;
-    final canOpenLease = propertyId != null && leaseId != null;
+    final unitAssets = request.unitAssets;
+    final blockAssets = request.blockAssets;
+    final canOpenLease = leaseId != null;
 
     return RLCard(
       padding: const EdgeInsets.symmetric(horizontal: 16),
@@ -592,17 +594,33 @@ class _PropertiesCard extends ConsumerWidget {
             label: 'Visibility',
             value: mrVisibilityLabelFromApi(request.visibility),
             onTap: () => _editSoon(context, ref, 'Changing visibility'),
-            last: !canOpenUnit && !canOpenLease,
+            last: unitAssets.isEmpty && blockAssets.isEmpty && !canOpenLease,
           ),
-          if (canOpenUnit)
+          for (final asset in unitAssets)
             _NavRow(
               label: 'Unit',
-              value: request.unit?.name ?? 'View unit',
-              last: !canOpenLease,
+              value: asset.label,
+              last:
+                  asset == unitAssets.last &&
+                  blockAssets.isEmpty &&
+                  !canOpenLease,
               onTap: () async {
                 await Haptics.vibrate(HapticsType.selection);
                 if (!context.mounted) return;
-                context.push('/properties/$propertyId/units/${request.unitId}');
+                context.push('/properties/$propertyId/units/${asset.unitId}');
+              },
+            ),
+          // There is no block detail screen, so a block row opens the
+          // property's blocks list — the closest existing destination.
+          for (final asset in blockAssets)
+            _NavRow(
+              label: 'Block',
+              value: asset.label,
+              last: asset == blockAssets.last && !canOpenLease,
+              onTap: () async {
+                await Haptics.vibrate(HapticsType.selection);
+                if (!context.mounted) return;
+                context.push('/properties/$propertyId/blocks');
               },
             ),
           if (canOpenLease)

--- a/apps/pm_mobile/lib/src/repository/models/maintenance_request_model.dart
+++ b/apps/pm_mobile/lib/src/repository/models/maintenance_request_model.dart
@@ -46,6 +46,61 @@ class MaintenanceUnitModel {
   Map<String, dynamic> toJson() => _$MaintenanceUnitModelToJson(this);
 }
 
+@JsonSerializable()
+class MaintenanceBlockModel {
+  final String id;
+  final String name;
+
+  MaintenanceBlockModel({required this.id, required this.name});
+
+  factory MaintenanceBlockModel.fromJson(Map<String, dynamic> json) =>
+      _$MaintenanceBlockModelFromJson(json);
+
+  Map<String, dynamic> toJson() => _$MaintenanceBlockModelToJson(this);
+}
+
+/// One asset a maintenance request concerns. Exactly one of [unit] /
+/// [propertyBlock] is populated, matching [assetType]. A block asset is
+/// common-area work that belongs to no unit, so a request can legitimately
+/// have no units at all.
+@JsonSerializable()
+class MaintenanceAssetModel {
+  final String id;
+  @JsonKey(name: 'asset_type')
+  final String assetType; // UNIT | BLOCK
+  @JsonKey(name: 'unit_id')
+  final String? unitId;
+  final MaintenanceUnitModel? unit;
+  @JsonKey(name: 'property_block_id')
+  final String? propertyBlockId;
+  @JsonKey(name: 'property_block')
+  final MaintenanceBlockModel? propertyBlock;
+
+  MaintenanceAssetModel({
+    required this.id,
+    required this.assetType,
+    this.unitId,
+    this.unit,
+    this.propertyBlockId,
+    this.propertyBlock,
+  });
+
+  bool get isUnit => assetType == 'UNIT';
+  bool get isBlock => assetType == 'BLOCK';
+
+  /// Display label, falling back to the asset type so a row is never blank
+  /// when the API returned the association without populating the relation.
+  String get label {
+    if (isUnit) return unit?.name ?? 'Unit';
+    return propertyBlock?.name ?? 'Block';
+  }
+
+  factory MaintenanceAssetModel.fromJson(Map<String, dynamic> json) =>
+      _$MaintenanceAssetModelFromJson(json);
+
+  Map<String, dynamic> toJson() => _$MaintenanceAssetModelToJson(this);
+}
+
 /// The tenant who raised a request, when one did. Only the name is modelled —
 /// the History timeline is the sole consumer and it just needs someone to
 /// attribute "Submitted by …" to.
@@ -80,9 +135,9 @@ class MaintenanceRequestModel {
   final String category;
   final String priority;
   final String status;
-  @JsonKey(name: 'unit_id')
-  final String unitId;
-  final MaintenanceUnitModel? unit;
+  @JsonKey(name: 'property_id')
+  final String propertyId;
+  final List<MaintenanceAssetModel>? assets;
   @JsonKey(name: 'lease_id')
   final String? leaseId;
 
@@ -147,8 +202,8 @@ class MaintenanceRequestModel {
     required this.category,
     required this.priority,
     required this.status,
-    required this.unitId,
-    this.unit,
+    required this.propertyId,
+    this.assets,
     this.leaseId,
     this.createdByTenantId,
     this.createdByTenant,
@@ -167,6 +222,25 @@ class MaintenanceRequestModel {
     this.createdAt,
     this.updatedAt,
   });
+
+  /// Unit assets only, never null. Screens iterate these directly.
+  List<MaintenanceAssetModel> get unitAssets =>
+      assets?.where((a) => a.isUnit).toList() ?? const [];
+
+  /// Block assets only, never null. A block-only request is common-area work
+  /// and has no units.
+  List<MaintenanceAssetModel> get blockAssets =>
+      assets?.where((a) => a.isBlock).toList() ?? const [];
+
+  /// Compact label for list/board cards: names the first asset and counts the
+  /// rest, so a request covering six units reads "A1 +5" rather than a wall
+  /// of names.
+  String get assetSummary {
+    final all = assets ?? const <MaintenanceAssetModel>[];
+    if (all.isEmpty) return '—';
+    final first = all.first.label;
+    return all.length > 1 ? '$first +${all.length - 1}' : first;
+  }
 
   factory MaintenanceRequestModel.fromJson(Map<String, dynamic> json) =>
       _$MaintenanceRequestModelFromJson(json);

--- a/apps/pm_mobile/lib/src/repository/models/maintenance_request_model.g.dart
+++ b/apps/pm_mobile/lib/src/repository/models/maintenance_request_model.g.dart
@@ -24,6 +24,47 @@ Map<String, dynamic> _$MaintenanceUnitModelToJson(
       'property_id': instance.propertyId,
     };
 
+MaintenanceBlockModel _$MaintenanceBlockModelFromJson(
+        Map<String, dynamic> json) =>
+    MaintenanceBlockModel(
+      id: json['id'] as String,
+      name: json['name'] as String,
+    );
+
+Map<String, dynamic> _$MaintenanceBlockModelToJson(
+        MaintenanceBlockModel instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+    };
+
+MaintenanceAssetModel _$MaintenanceAssetModelFromJson(
+        Map<String, dynamic> json) =>
+    MaintenanceAssetModel(
+      id: json['id'] as String,
+      assetType: json['asset_type'] as String,
+      unitId: json['unit_id'] as String?,
+      unit: json['unit'] == null
+          ? null
+          : MaintenanceUnitModel.fromJson(json['unit'] as Map<String, dynamic>),
+      propertyBlockId: json['property_block_id'] as String?,
+      propertyBlock: json['property_block'] == null
+          ? null
+          : MaintenanceBlockModel.fromJson(
+              json['property_block'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$MaintenanceAssetModelToJson(
+        MaintenanceAssetModel instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'asset_type': instance.assetType,
+      'unit_id': instance.unitId,
+      'unit': instance.unit,
+      'property_block_id': instance.propertyBlockId,
+      'property_block': instance.propertyBlock,
+    };
+
 MaintenanceTenantModel _$MaintenanceTenantModelFromJson(
         Map<String, dynamic> json) =>
     MaintenanceTenantModel(
@@ -50,10 +91,11 @@ MaintenanceRequestModel _$MaintenanceRequestModelFromJson(
       category: json['category'] as String,
       priority: json['priority'] as String,
       status: json['status'] as String,
-      unitId: json['unit_id'] as String,
-      unit: json['unit'] == null
-          ? null
-          : MaintenanceUnitModel.fromJson(json['unit'] as Map<String, dynamic>),
+      propertyId: json['property_id'] as String,
+      assets: (json['assets'] as List<dynamic>?)
+          ?.map(
+              (e) => MaintenanceAssetModel.fromJson(e as Map<String, dynamic>))
+          .toList(),
       leaseId: json['lease_id'] as String?,
       createdByTenantId: json['created_by_tenant_id'] as String?,
       createdByTenant: json['created_by_tenant'] == null
@@ -89,8 +131,8 @@ Map<String, dynamic> _$MaintenanceRequestModelToJson(
       'category': instance.category,
       'priority': instance.priority,
       'status': instance.status,
-      'unit_id': instance.unitId,
-      'unit': instance.unit?.toJson(),
+      'property_id': instance.propertyId,
+      'assets': instance.assets?.map((e) => e.toJson()).toList(),
       'lease_id': instance.leaseId,
       'created_by_tenant_id': instance.createdByTenantId,
       'created_by_tenant': instance.createdByTenant?.toJson(),

--- a/apps/pm_mobile/lib/src/repository/notifiers/activity/maintenance_request_status_notifier.dart
+++ b/apps/pm_mobile/lib/src/repository/notifiers/activity/maintenance_request_status_notifier.dart
@@ -31,8 +31,10 @@ class MaintenanceRequestStatusNotifier
     String? cancellationReason,
   }) async {
     final clientId = ref.read(currentWorkspaceNotifierProvider)?.clientId;
-    final propertyId = request.unit?.propertyId;
-    if (clientId == null || propertyId == null) {
+    // The request carries its own property, so this no longer fails when the
+    // unit relation was not populated.
+    final propertyId = request.propertyId;
+    if (clientId == null) {
       state = MaintenanceRequestStatusState(
         status: ApiStatus.failed,
         errorMessage: translateApiErrorMessage(),

--- a/apps/pm_mobile/lib/src/repository/providers/activity/maintenance_detail_provider.dart
+++ b/apps/pm_mobile/lib/src/repository/providers/activity/maintenance_detail_provider.dart
@@ -50,8 +50,7 @@ Future<String> maintenanceRequestPropertyId(
       .getMaintenanceRequests(clientId: clientId, pageSize: _scanPageSize);
 
   for (final row in page.rows) {
-    final propertyId = row.unit?.propertyId;
-    if (row.id == requestId && propertyId != null) return propertyId;
+    if (row.id == requestId) return row.propertyId;
   }
 
   throw StateError('Could not locate this request. Open it from the board.');

--- a/apps/pm_mobile/test/api/maintenance_request_api_test.dart
+++ b/apps/pm_mobile/test/api/maintenance_request_api_test.dart
@@ -82,7 +82,7 @@ void main() {
       expect(api.paths.single, isNot(contains('populate=')));
     });
 
-    test('the single request populates unit, assignees and creators', () async {
+    test('the single request populates assets, assignees and creators', () async {
       final api = _RecordingApi()
         ..nextBody = {
           'data': {
@@ -92,7 +92,7 @@ void main() {
             'category': 'OTHER',
             'priority': 'LOW',
             'status': 'NEW',
-            'unit_id': 'u1',
+            'property_id': 'p1',
           },
         };
       await api.getMaintenanceRequest(
@@ -103,7 +103,9 @@ void main() {
 
       final path = api.paths.single;
       for (final relation in [
-        'Unit',
+        'Assets',
+        'Assets.Unit',
+        'Assets.PropertyBlock',
         'AssignedWorker.User',
         'AssignedManager.User',
         'CreatedByTenant',

--- a/apps/pm_mobile/test/modules/main/activity/maintenance_detail_test.dart
+++ b/apps/pm_mobile/test/modules/main/activity/maintenance_detail_test.dart
@@ -21,13 +21,20 @@ MaintenanceRequestModel _fixture() => MaintenanceRequestModel(
   category: 'ELECTRICAL',
   priority: 'MEDIUM',
   status: 'RESOLVED',
-  unitId: 'unit1',
-  unit: MaintenanceUnitModel(
-    id: 'unit1',
-    name: "Domey's Residence",
-    slug: 'domeys-residence',
-    propertyId: _propertyId,
-  ),
+  propertyId: _propertyId,
+  assets: [
+    MaintenanceAssetModel(
+      id: 'asset1',
+      assetType: 'UNIT',
+      unitId: 'unit1',
+      unit: MaintenanceUnitModel(
+        id: 'unit1',
+        name: "Domey's Residence",
+        slug: 'domeys-residence',
+        propertyId: _propertyId,
+      ),
+    ),
+  ],
   leaseId: 'lease1',
   visibility: 'TENANT_VISIBLE',
   createdByClientUserId: 'm1',

--- a/apps/pm_mobile/test/repository/models/maintenance_detail_models_test.dart
+++ b/apps/pm_mobile/test/repository/models/maintenance_detail_models_test.dart
@@ -14,7 +14,15 @@ void main() {
         'category': 'PLUMBING',
         'priority': 'HIGH',
         'status': 'IN_REVIEW',
-        'unit_id': 'u1',
+        'property_id': 'p1',
+        'assets': [
+          {
+            'id': 'a1',
+            'asset_type': 'UNIT',
+            'unit_id': 'u1',
+            'unit': {'id': 'u1', 'name': 'A1', 'slug': 'a1'},
+          },
+        ],
         'lease_id': 'l1',
         'attachments': ['https://cdn.test/a.jpg', 'https://cdn.test/b.pdf'],
         'visibility': 'INTERNAL_ONLY',
@@ -26,6 +34,68 @@ void main() {
       expect(model.visibility, 'INTERNAL_ONLY');
       expect(model.leaseId, 'l1');
       expect(model.reviewedAt, '2026-03-16T11:52:00Z');
+      expect(model.propertyId, 'p1');
+      expect(model.unitAssets, hasLength(1));
+      expect(model.unitAssets.first.label, 'A1');
+      expect(model.blockAssets, isEmpty);
+      expect(model.assetSummary, 'A1');
+    });
+
+    test('parses a request covering several units and a block', () {
+      final model = MaintenanceRequestModel.fromJson({
+        'id': 'mr2',
+        'code': 'MULTI',
+        'title': 'Riser serving A1-A2 plus the stairwell',
+        'category': 'PLUMBING',
+        'priority': 'HIGH',
+        'status': 'NEW',
+        'property_id': 'p1',
+        'assets': [
+          {
+            'id': 'a1',
+            'asset_type': 'UNIT',
+            'unit_id': 'u1',
+            'unit': {'id': 'u1', 'name': 'A1', 'slug': 'a1'},
+          },
+          {
+            'id': 'a2',
+            'asset_type': 'UNIT',
+            'unit_id': 'u2',
+            'unit': {'id': 'u2', 'name': 'A2', 'slug': 'a2'},
+          },
+          {
+            'id': 'a3',
+            'asset_type': 'BLOCK',
+            'property_block_id': 'b1',
+            'property_block': {'id': 'b1', 'name': 'Block A'},
+          },
+        ],
+      });
+
+      expect(model.unitAssets, hasLength(2));
+      expect(model.blockAssets, hasLength(1));
+      expect(model.blockAssets.first.label, 'Block A');
+      expect(model.assetSummary, 'A1 +2');
+    });
+
+    test('falls back to the asset type when a relation is not populated', () {
+      // The API returns the association even when the relation was not asked
+      // for, so a card must never render a blank label.
+      final model = MaintenanceRequestModel.fromJson({
+        'id': 'mr3',
+        'code': 'BARE',
+        'title': 'Unpopulated',
+        'category': 'OTHER',
+        'priority': 'LOW',
+        'status': 'NEW',
+        'property_id': 'p1',
+        'assets': [
+          {'id': 'a1', 'asset_type': 'BLOCK', 'property_block_id': 'b1'},
+        ],
+      });
+
+      expect(model.blockAssets.first.label, 'Block');
+      expect(model.assetSummary, 'Block');
     });
 
     test('defaults attachments and visibility when the API omits them', () {
@@ -38,11 +108,15 @@ void main() {
         'category': 'OTHER',
         'priority': 'LOW',
         'status': 'NEW',
-        'unit_id': 'u1',
+        'property_id': 'p1',
       });
 
       expect(model.attachments, isEmpty);
       expect(model.visibility, 'TENANT_VISIBLE');
+      // No assets key at all must not throw, and must not render blank.
+      expect(model.unitAssets, isEmpty);
+      expect(model.blockAssets, isEmpty);
+      expect(model.assetSummary, '—');
       expect(model.leaseId, isNull);
     });
   });

--- a/apps/property-manager/app/api/maintenance-requests/index.ts
+++ b/apps/property-manager/app/api/maintenance-requests/index.ts
@@ -73,7 +73,9 @@ export interface CreateMaintenanceRequestInput {
 	description: string
 	priority: MaintenanceRequestPriority
 	category: MaintenanceRequestCategory
-	unit_id: string
+	unit_ids: Array<string>
+	block_ids: Array<string>
+	create_separate_requests: boolean
 	visibility: MaintenanceRequest['visibility']
 	attachments: Array<string>
 }
@@ -84,7 +86,9 @@ const createMaintenanceRequest = async ({
 	...input
 }: CreateMaintenanceRequestInput) => {
 	try {
-		const response = await fetchClient<ApiResponse<MaintenanceRequest>>(
+		// Always an array: one request normally, one per asset when the caller
+		// asked for separate requests.
+		const response = await fetchClient<ApiResponse<MaintenanceRequest[]>>(
 			`/v1/admin/clients/${client_id}/properties/${property_id}/maintenance-requests`,
 			{
 				method: 'POST',

--- a/apps/property-manager/app/api/maintenance-requests/server.ts
+++ b/apps/property-manager/app/api/maintenance-requests/server.ts
@@ -7,7 +7,7 @@ export const getMaintenanceRequestForServer = async (
 ) => {
 	try {
 		const response = await fetchServer<ApiResponse<MaintenanceRequest>>(
-			`${apiConfig.baseUrl}/v1/admin/clients/${clientId}/properties/${props.property_id}/maintenance-requests/${props.request_id}?populate=Unit,AssignedWorker,AssignedWorker.User,AssignedManager,AssignedManager.User,CreatedByTenant,CreatedByClientUser.User`,
+			`${apiConfig.baseUrl}/v1/admin/clients/${clientId}/properties/${props.property_id}/maintenance-requests/${props.request_id}?populate=Assets,Assets.Unit,Assets.PropertyBlock,AssignedWorker,AssignedWorker.User,AssignedManager,AssignedManager.User,CreatedByTenant,CreatedByClientUser.User`,
 			{ ...apiConfig },
 		)
 		return response.parsedBody.data

--- a/apps/property-manager/app/modules/insights/overview/risk-detail-modal.tsx
+++ b/apps/property-manager/app/modules/insights/overview/risk-detail-modal.tsx
@@ -40,6 +40,19 @@ function fullName(
 	return `${safeString(first)} ${safeString(last)}`.trim()
 }
 
+// A request can cover several units and blocks, so the subtitle names the first
+// asset and counts the rest rather than pretending there is a single unit.
+function assetSummary(assets: MaintenanceRequestAsset[] | undefined): string {
+	const first = assets?.[0]
+	if (!first) return ''
+	const label =
+		first.asset_type === 'UNIT'
+			? (first.unit?.name ?? 'Unit')
+			: (first.property_block?.name ?? 'Block')
+	const rest = (assets?.length ?? 0) - 1
+	return rest > 0 ? `${label} +${rest}` : label
+}
+
 function useRiskRecords(
 	type: InsightsRiskType,
 	open: boolean,
@@ -93,7 +106,7 @@ function useRiskRecords(
 		clientId,
 		{
 			pagination: { page: 1, per: PAGE_SIZE },
-			populate: ['Unit', 'Unit.Property'],
+			populate: ['Property', 'Assets', 'Assets.Unit', 'Assets.PropertyBlock'],
 			filters: {
 				status: ['NEW', 'IN_PROGRESS', 'IN_REVIEW'],
 				property_id: propertyId,
@@ -154,10 +167,13 @@ function useRiskRecords(
 			for (const request of page?.rows ?? []) {
 				records.push({
 					id: request.id,
-					propertyId: safeString(request.unit?.property_id),
-					propertyName: safeString(request.unit?.property?.name),
+					// The request carries its own property now, so this no longer
+					// depends on a unit being populated — a block-only request has
+					// no unit at all.
+					propertyId: safeString(request.property_id),
+					propertyName: safeString(request.property?.name),
 					title: request.title,
-					subtitle: safeString(request.unit?.name),
+					subtitle: assetSummary(request.assets),
 					value: request.priority,
 				})
 			}

--- a/apps/property-manager/app/modules/properties/property/activities/maintenance-requests/controller.tsx
+++ b/apps/property-manager/app/modules/properties/property/activities/maintenance-requests/controller.tsx
@@ -1,4 +1,5 @@
 import { ToggleLeft } from 'lucide-react'
+import { getPropertyBlocks } from '~/api/blocks'
 import { getClientUserProperties } from '~/api/client-user-properties'
 import { getPropertyUnits } from '~/api/units'
 import { FilterSet } from '~/components/filter-set'
@@ -112,6 +113,36 @@ export function PropertyActivitiesMaintenanceRequestsController() {
 		},
 		...(isMultiUnit
 			? ([
+					{
+						id: 6,
+						type: 'selector',
+						selectType: 'multi',
+						label: 'Block',
+						value: {
+							onSearch: async ({ ids }) => {
+								if (!propertyId) return []
+								const data = await getPropertyBlocks(clientId, {
+									property_id: propertyId,
+									filters: {
+										ids: ids?.map((id) => id.toString()),
+									},
+									pagination: {
+										page: PAGINATION_DEFAULTS.PAGE,
+										per: PAGINATION_DEFAULTS.PER_PAGE,
+									},
+								})
+								return (
+									data?.rows.map((block) => ({
+										label: block.name,
+										value: block.id,
+									})) ?? []
+								)
+							},
+							urlParam: 'block',
+							defaultValues: [],
+						},
+						Icon: ToggleLeft,
+					},
 					{
 						id: 5,
 						type: 'selector',

--- a/apps/property-manager/app/modules/properties/property/activities/maintenance-requests/index.tsx
+++ b/apps/property-manager/app/modules/properties/property/activities/maintenance-requests/index.tsx
@@ -96,6 +96,7 @@ export function PropertyActivitiesMaintenanceRequestsModule() {
 	const assignedWorkerId = searchParams.get('assigned_worker') ?? undefined
 	const assignedManagerId = searchParams.get('assigned_manager') ?? undefined
 	const unitId = searchParams.get('unit') ?? undefined
+	const blockId = searchParams.get('block') ?? undefined
 
 	const columnParams = (status: MaintenanceRequestStatus) => ({
 		filters: {
@@ -105,10 +106,13 @@ export function PropertyActivitiesMaintenanceRequestsModule() {
 			assigned_worker_id: assignedWorkerId,
 			assigned_manager_id: assignedManagerId,
 			unit_id: unitId,
+			block_id: blockId,
 		},
 		pagination: { page: 1, per: 50 },
 		populate: [
-			'Unit',
+			'Assets',
+			'Assets.Unit',
+			'Assets.PropertyBlock',
 			'AssignedWorker',
 			'AssignedWorker.User',
 			'AssignedManager',

--- a/apps/property-manager/app/modules/properties/property/activities/maintenance-requests/new/index.tsx
+++ b/apps/property-manager/app/modules/properties/property/activities/maintenance-requests/new/index.tsx
@@ -5,11 +5,13 @@ import { useForm } from 'react-hook-form'
 import { Link, useNavigate, useParams } from 'react-router'
 import { toast } from 'sonner'
 import { z } from 'zod'
+import { useGetPropertyBlocks } from '~/api/blocks'
 import {
 	useCreateMaintenanceRequest,
 	type CreateMaintenanceRequestInput,
 } from '~/api/maintenance-requests'
 import { useGetPropertyUnits } from '~/api/units'
+import { MultiSelect } from '~/components/multi-select'
 import { Button } from '~/components/ui/button'
 import {
 	Form,
@@ -28,6 +30,7 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from '~/components/ui/select'
+import { Switch } from '~/components/ui/switch'
 import { Textarea } from '~/components/ui/textarea'
 import { TypographyH3, TypographyMuted } from '~/components/ui/typography'
 import { useUploadObjectBulk } from '~/hooks/use-upload-object-bulk'
@@ -42,19 +45,33 @@ const CATEGORY_VALUES = Object.keys(CATEGORY_LABELS) as [
 	...MaintenanceRequestCategory[],
 ]
 
-const schema = z.object({
-	title: z.string().min(1, 'Title is required'),
-	description: z.string().min(1, 'Description is required'),
-	priority: z.enum(['LOW', 'MEDIUM', 'HIGH', 'EMERGENCY'], {
-		error: 'Priority is required',
-	}),
-	category: z.enum(CATEGORY_VALUES, {
-		error: 'Category is required',
-	}),
-	unit_id: z.string({ error: 'Unit is required' }).min(1, 'Unit is required'),
-	visibility: z.enum(['TENANT_VISIBLE', 'INTERNAL_ONLY']),
-	attachments: z.array(z.string()).optional(),
-})
+const schema = z
+	.object({
+		title: z.string().min(1, 'Title is required'),
+		description: z.string().min(1, 'Description is required'),
+		priority: z.enum(['LOW', 'MEDIUM', 'HIGH', 'EMERGENCY'], {
+			error: 'Priority is required',
+		}),
+		category: z.enum(CATEGORY_VALUES, {
+			error: 'Category is required',
+		}),
+		unit_ids: z.array(z.string()),
+		block_ids: z.array(z.string()),
+		create_separate_requests: z.boolean(),
+		visibility: z.enum(['TENANT_VISIBLE', 'INTERNAL_ONLY']),
+		attachments: z.array(z.string()).optional(),
+	})
+	.superRefine((values, ctx) => {
+		// A request must concern something. Reported on unit_ids so the message
+		// lands next to the units picker.
+		if (values.unit_ids.length === 0 && values.block_ids.length === 0) {
+			ctx.addIssue({
+				code: 'custom',
+				path: ['unit_ids'],
+				message: 'Select at least one block or unit',
+			})
+		}
+	})
 
 type FormValues = z.infer<typeof schema>
 
@@ -78,6 +95,14 @@ export function NewPropertyActivitiesMaintenanceRequestModule() {
 		},
 	)
 
+	const { data: blocks } = useGetPropertyBlocks(
+		safeString(clientUser?.client_id),
+		{
+			property_id: resolvedPropertyId,
+			pagination: { page: 1, per: 200 },
+		},
+	)
+
 	const { upload, remove, uploadingIds, uploadedUrls, isUploading } =
 		useUploadObjectBulk('maintenance-requests')
 
@@ -88,15 +113,51 @@ export function NewPropertyActivitiesMaintenanceRequestModule() {
 			description: '',
 			priority: undefined,
 			category: undefined,
-			unit_id: undefined,
+			unit_ids: [],
+			block_ids: [],
+			create_separate_requests: false,
 			visibility: 'TENANT_VISIBLE',
 			attachments: [],
 		},
 	})
 
+	const selectedUnitIds = form.watch('unit_ids')
+	const selectedBlockIds = form.watch('block_ids')
+	const fanOut = form.watch('create_separate_requests')
+
+	const assetCount = selectedUnitIds.length + selectedBlockIds.length
+
+	// With fan-out on, each unit becomes its own single-unit request and may stay
+	// tenant-visible; block requests are always internal. With fan-out off,
+	// anything broader than one unit is internal.
+	const forcedInternal = fanOut
+		? selectedUnitIds.length === 0
+		: selectedBlockIds.length > 0 || assetCount > 1
+
+	const blockOptions = (blocks?.rows ?? []).map((block) => ({
+		label: block.name,
+		value: block.id,
+	}))
+
+	// Units are grouped by their block so a large property stays scannable.
+	const unitGroups = (blocks?.rows ?? [])
+		.map((block) => ({
+			heading: block.name,
+			options: (units?.rows ?? [])
+				.filter((unit) => unit.property_block_id === block.id)
+				.map((unit) => ({ label: unit.name, value: unit.id })),
+		}))
+		.filter((group) => group.options.length > 0)
+
 	useEffect(() => {
 		form.setValue('attachments', uploadedUrls)
 	}, [uploadedUrls, form])
+
+	useEffect(() => {
+		if (forcedInternal) {
+			form.setValue('visibility', 'INTERNAL_ONLY')
+		}
+	}, [forcedInternal, form])
 
 	const onSubmit = async (values: FormValues) => {
 		try {
@@ -107,18 +168,31 @@ export function NewPropertyActivitiesMaintenanceRequestModule() {
 				priority: values.priority,
 				category: values.category,
 				visibility: values.visibility,
-				unit_id: values.unit_id,
+				unit_ids: values.unit_ids,
+				block_ids: values.block_ids,
+				create_separate_requests: values.create_separate_requests,
 				property_id: resolvedPropertyId,
 				attachments: values.attachments ?? [],
 			}
-			await createRequest.mutateAsync(input)
-			toast.success('Maintenance request created')
+			const created = await createRequest.mutateAsync(input)
+
 			void queryClient.invalidateQueries({
 				queryKey: [QUERY_KEYS.MAINTENANCE_REQUESTS],
 			})
-			void navigate(
-				`/properties/${resolvedPropertyId}/activities/maintenance-requests`,
-			)
+
+			const listPath = `/properties/${resolvedPropertyId}/activities/maintenance-requests`
+
+			// A single request goes straight to its detail page; a fan-out has no
+			// single destination, so land on the board instead.
+			const onlyRequest = created?.length === 1 ? created[0] : undefined
+			if (onlyRequest) {
+				toast.success('Maintenance request created')
+				void navigate(`${listPath}/${onlyRequest.id}`)
+				return
+			}
+
+			toast.success(`${created?.length ?? 0} maintenance requests created`)
+			void navigate(listPath)
 		} catch (err) {
 			toast.error(
 				err instanceof Error ? err.message : 'Failed to create request',
@@ -131,40 +205,89 @@ export function NewPropertyActivitiesMaintenanceRequestModule() {
 			<div>
 				<TypographyH3>New Maintenance Request</TypographyH3>
 				<TypographyMuted>
-					Report a new maintenance issue for a unit.
+					Report a new maintenance issue for one or more blocks or units.
 				</TypographyMuted>
 			</div>
 
 			<Form {...form}>
 				<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-					<div className="grid grid-cols-2">
+					<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
 						<FormField
 							control={form.control}
-							name="unit_id"
+							name="block_ids"
 							render={({ field }) => (
-								<FormItem className="">
-									<FormLabel>
-										Unit <span className="text-red-600">*</span>
-									</FormLabel>
-									<Select onValueChange={field.onChange} value={field.value}>
-										<FormControl>
-											<SelectTrigger className="w-full">
-												<SelectValue placeholder="Select unit" />
-											</SelectTrigger>
-										</FormControl>
-										<SelectContent>
-											{units?.rows.map((unit) => (
-												<SelectItem key={unit.id} value={unit.id}>
-													{unit.name}
-												</SelectItem>
-											))}
-										</SelectContent>
-									</Select>
+								<FormItem>
+									<FormLabel>Blocks</FormLabel>
+									<FormControl>
+										<MultiSelect
+											options={blockOptions}
+											defaultValue={field.value}
+											onValueChange={field.onChange}
+											placeholder="Select blocks"
+											maxCount={3}
+											className="w-full"
+										/>
+									</FormControl>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
+
+						<FormField
+							control={form.control}
+							name="unit_ids"
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>Units</FormLabel>
+									<FormControl>
+										<MultiSelect
+											options={unitGroups}
+											defaultValue={field.value}
+											onValueChange={field.onChange}
+											placeholder="Select units"
+											maxCount={3}
+											className="w-full"
+										/>
+									</FormControl>
 									<FormMessage />
 								</FormItem>
 							)}
 						/>
 					</div>
+
+					{assetCount > 1 && (
+						<FormField
+							control={form.control}
+							name="create_separate_requests"
+							render={({ field }) => (
+								<FormItem className="flex flex-row items-start gap-3 rounded-md border p-4">
+									<FormControl>
+										<Switch
+											checked={field.value}
+											onCheckedChange={field.onChange}
+										/>
+									</FormControl>
+									<div className="space-y-1">
+										<FormLabel>Create separate requests</FormLabel>
+										<TypographyMuted>
+											Creates one request per selected asset. Each unit request
+											can still notify its tenant.
+										</TypographyMuted>
+									</div>
+								</FormItem>
+							)}
+						/>
+					)}
+
+					{forcedInternal && (
+						<div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3">
+							<TypographyMuted className="text-amber-700 dark:text-amber-400">
+								{selectedUnitIds.length === 0
+									? 'Block work has no tenant attached, so this request will be Internal Only.'
+									: 'This request covers more than one asset, so it will be Internal Only and no tenant is notified. Turn on “Create separate requests” to notify each tenant.'}
+							</TypographyMuted>
+						</div>
+					)}
 					<FormField
 						control={form.control}
 						name="title"
@@ -289,7 +412,11 @@ export function NewPropertyActivitiesMaintenanceRequestModule() {
 							name="visibility"
 							render={({ field }) => (
 								<FormItem>
-									<Select onValueChange={field.onChange} value={field.value}>
+									<Select
+										onValueChange={field.onChange}
+										value={field.value}
+										disabled={forcedInternal}
+									>
 										<FormControl>
 											<SelectTrigger className="w-full">
 												<SelectValue placeholder="Select visibility" />

--- a/apps/property-manager/app/modules/properties/property/activities/maintenance-requests/request-card.tsx
+++ b/apps/property-manager/app/modules/properties/property/activities/maintenance-requests/request-card.tsx
@@ -30,6 +30,22 @@ interface RequestCardProps {
 	propertyId: string
 }
 
+// Names the first asset and counts the rest. The API returns the association
+// even when the relation was not populated, so fall back to the type rather
+// than rendering a blank chip.
+const assetSummary = (
+	assets: MaintenanceRequestAsset[] | undefined,
+): string | null => {
+	const first = assets?.[0]
+	if (!first) return null
+	const label =
+		first.asset_type === 'UNIT'
+			? (first.unit?.name ?? 'Unit')
+			: (first.property_block?.name ?? 'Block')
+	const rest = (assets?.length ?? 0) - 1
+	return rest > 0 ? `${label} +${rest}` : label
+}
+
 export function RequestCard({ item, propertyId }: RequestCardProps) {
 	const [assignDialogOpen, setAssignDialogOpen] = useState(false)
 	const [assignType, setAssignType] = useState<'worker' | 'manager'>('worker')
@@ -100,6 +116,14 @@ export function RequestCard({ item, propertyId }: RequestCardProps) {
 						>
 							{CATEGORY_LABELS[item.category]}
 						</Badge>
+						{assetSummary(item.assets) ? (
+							<Badge
+								variant="outline"
+								className="text-muted-foreground px-1.5 py-0 text-[10px] font-normal"
+							>
+								{assetSummary(item.assets)}
+							</Badge>
+						) : null}
 					</div>
 
 					{(workerInitials || managerInitials) && (

--- a/apps/property-manager/app/modules/properties/property/activities/maintenance-requests/request/sidebar.tsx
+++ b/apps/property-manager/app/modules/properties/property/activities/maintenance-requests/request/sidebar.tsx
@@ -500,15 +500,28 @@ export function MaintenanceRequestSidebar({ mr, propertyId }: SidebarProps) {
 								</SelectContent>
 							</Select>
 						</SidebarRow>
-						{mr.unit && (
-							<SidebarRow label="Unit">
-								<Link
-									to={`/properties/${propertyId}/assets/units/${mr.unit_id}`}
-									className="text-xs text-blue-600 hover:underline dark:text-blue-400"
-								>
-									{mr.unit.name}
-								</Link>
-							</SidebarRow>
+						{mr.assets?.map((asset) =>
+							asset.asset_type === 'UNIT' ? (
+								<SidebarRow key={asset.id} label="Unit">
+									<Link
+										to={`/properties/${propertyId}/assets/units/${asset.unit_id}`}
+										className="text-xs text-blue-600 hover:underline dark:text-blue-400"
+									>
+										{asset.unit?.name ?? 'View unit'}
+									</Link>
+								</SidebarRow>
+							) : (
+								// No block detail route exists — only list, new and
+								// $blockId/edit — so link to the list.
+								<SidebarRow key={asset.id} label="Block">
+									<Link
+										to={`/properties/${propertyId}/assets/blocks`}
+										className="text-xs text-blue-600 hover:underline dark:text-blue-400"
+									>
+										{asset.property_block?.name ?? 'View block'}
+									</Link>
+								</SidebarRow>
+							),
 						)}
 						{mr.lease_id && (
 							<SidebarRow label="Lease">

--- a/apps/property-manager/types/maintenance.d.ts
+++ b/apps/property-manager/types/maintenance.d.ts
@@ -1,8 +1,18 @@
+interface MaintenanceRequestAsset {
+	id: string
+	asset_type: 'UNIT' | 'BLOCK'
+	unit_id?: string
+	unit?: PropertyUnit
+	property_block_id?: string
+	property_block?: PropertyBlock
+}
+
 interface MaintenanceRequest {
 	id: string
 	code: string
-	unit_id: string
-	unit?: PropertyUnit
+	property_id: string
+	property?: Property
+	assets: MaintenanceRequestAsset[]
 	lease_id: Nullable<string>
 	created_by_tenant_id: Nullable<string>
 	created_by_tenant?: Nullable<Tenant>
@@ -65,7 +75,6 @@ interface MaintenanceRequestActivityLog {
 	performed_by_tenant_id: Nullable<string>
 	performed_by_tenant: Nullable<Tenant>
 	metadata: Nullable<Record<string, unknown>>
-	metadata: Nullable<Record<string, unknown>>
 	created_at: string
 	updated_at: string
 }
@@ -101,6 +110,7 @@ interface FetchMaintenanceRequestFilter {
 	tenant_id?: string
 	property_id?: string
 	unit_id?: string
+	block_id?: string
 	assigned_worker_id?: string
 	assigned_manager_id?: string
 }

--- a/backlog/tasks/rentl-48 - Maintenance-Requests-—-multi-asset-targeting-blocks-units.md
+++ b/backlog/tasks/rentl-48 - Maintenance-Requests-—-multi-asset-targeting-blocks-units.md
@@ -1,0 +1,44 @@
+---
+id: RENTL-48
+title: Maintenance Requests — multi-asset targeting (blocks + units)
+status: To Do
+assignee: []
+created_date: '2026-08-01 14:19'
+labels:
+  - maintenance-requests
+  - backend
+  - frontend
+  - mobile
+dependencies: []
+documentation:
+  - docs/superpowers/specs/2026-08-01-maintenance-request-multi-asset-design.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Landlords can currently attach a maintenance request to exactly one unit. They need to be able to select multiple units and one or more blocks on a single request.
+
+Blocks are first-class targets, not shorthand for their units — a lot of maintenance work is common-area work (roof, corridor, generator, stairwell) that belongs to no unit and cannot be logged today.
+
+This parent tracks the whole change across the backend, the property manager portal, both Flutter apps, and the Cube.js analytics schema. The approved design — including all decisions, the data model, visibility rules, and the migration plan — is in docs/superpowers/specs/2026-08-01-maintenance-request-multi-asset-design.md. Read it before starting any subtask.
+
+Key decisions a stranger needs to know:
+- MaintenanceRequest.UnitID is dropped, replaced by a single MaintenanceRequestAsset table with an AssetType discriminator (UNIT | BLOCK) and nullable UnitID / PropertyBlockID.
+- A denormalized PropertyID is added to MaintenanceRequest, because property scoping and access control run on every list/count/stats query.
+- Any request with more than one asset, or with any block, is forced to INTERNAL_ONLY. Only the single-unit case can be tenant-visible, which preserves today's tenant behaviour exactly.
+- An opt-in fan-out toggle creates one single-asset request per selected asset, so landlords can still notify each tenant.
+- Assets are immutable after creation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A landlord can create one maintenance request targeting any combination of multiple units and multiple blocks
+- [ ] #2 A landlord can create a maintenance request for a block alone, with no unit selected, to cover common-area work
+- [ ] #3 A request with exactly one unit and no blocks behaves exactly as today: the tenant sees it in their lease feed and receives a push notification
+- [ ] #4 A request with more than one asset, or with any block, is internal-only and notifies no tenant
+- [ ] #5 With the fan-out option enabled, one request is created per selected asset; unit requests can still be tenant-visible while block requests are internal-only
+- [ ] #6 Existing maintenance requests continue to display, filter, and report correctly after migration
+- [ ] #7 Maintenance analytics remain correctly scoped to the caller's permitted properties after the change
+<!-- AC:END -->

--- a/backlog/tasks/rentl-48.1 - Backend-—-maintenance-request-assets-model-migration-and-API.md
+++ b/backlog/tasks/rentl-48.1 - Backend-—-maintenance-request-assets-model-migration-and-API.md
@@ -1,0 +1,79 @@
+---
+id: RENTL-48.1
+title: 'Backend — maintenance request assets model, migration, and API'
+status: In Progress
+assignee: []
+created_date: '2026-08-01 14:19'
+updated_date: '2026-08-01 14:57'
+labels:
+  - maintenance-requests
+  - backend
+dependencies: []
+references:
+  - services/main/internal/models/maintenance-request.go
+  - services/main/internal/repository/maintenance-request.go
+  - services/main/internal/services/maintenance-request.go
+  - services/main/internal/handlers/maintenance-request.go
+  - services/main/internal/transformations/maintenance-request.go
+  - services/main/init/migration/main.go
+  - services/main/init/migration/jobs/fix-lad-lease-id-partial-unique-index.go
+documentation:
+  - docs/superpowers/specs/2026-08-01-maintenance-request-multi-asset-design.md
+parent_task_id: RENTL-48
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replace the single-unit foreign key on maintenance requests with a multi-asset model, and expose it through the API. This is the foundation — every other subtask depends on the payload shape it lands.
+
+Read docs/superpowers/specs/2026-08-01-maintenance-request-multi-asset-design.md first. It contains the exact model definition, the CHECK constraint and partial unique index SQL, the visibility matrix, and the migration steps.
+
+Scope: services/main only. Model, migration job, repository scopes, service, handlers, transformations, Swagger.
+
+Notes for whoever picks this up:
+- Visibility is computed by the service and silently downgraded, never trusted from the client. This matches how CreateByAdmin already downgrades when a unit has no active lease.
+- LeaseID and CreatedByTenantID stay on the request. They are only populated when the request has exactly one asset and it is a unit, which is precisely when a request may be tenant-visible. Tenant endpoints scope by lease_id and must not change.
+- The at-least-one-asset rule cannot be expressed in validator struct tags; validate it explicitly.
+- The denormalized property_id exists so property scoping and client-user access control stay simple; do not reintroduce subqueries through units.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A maintenance request can be created with any combination of unit ids and block ids, and rejects a request with neither
+- [ ] #2 Creating a request with an asset that belongs to a different property is rejected with a clear error naming the offending asset
+- [ ] #3 Effective visibility is forced to internal-only when a request has more than one asset or any block, and is honoured as requested for a single-unit request
+- [ ] #4 Enabling the fan-out option creates one single-asset request per selected asset, with block requests internal-only and unit requests honouring the requested visibility
+- [ ] #5 The create endpoint always responds with an array of created requests, including when only one is created
+- [ ] #6 Maintenance request responses expose the property and the full asset list, and no longer expose a single unit
+- [ ] #7 Requests can be filtered by unit, by block, and by property, and a request matching two selected units is returned only once
+- [ ] #8 Tenant lease-scoped endpoints return the same results as before the change for single-unit requests
+- [ ] #9 The migration backfills exactly one unit asset and a correct property for every pre-existing request, and is reversible
+- [ ] #10 Database constraints reject an asset row whose type and populated foreign key disagree, and reject duplicate assets on the same request
+- [ ] #11 Swagger annotations are updated for every changed handler, including the new block filter and the array-shaped create response
+- [ ] #12 Tests cover the visibility matrix, fan-out, asset validation, the new filter scopes, and the migration backfill
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implementation complete and unstaged; awaiting the API smoke test before this can be closed.
+
+Verified:
+- go build ./... clean; go test ./... passing (8 new planner tests cover the full visibility matrix, fan-out, dedupe, empty-selection rejection).
+- Migration applied to local dev DB. unit_id dropped, property_id NOT NULL, migration recorded.
+- CHECK constraint and both partial unique indexes verified functionally in a rolled-back transaction: valid unit and block assets insert; asset_type/FK mismatch rejected; both-FKs-set rejected; duplicate unit asset on the same request rejected by idx_mra_request_unit.
+- Server boots cleanly with the new model wiring.
+- Swagger regenerated: unit_ids / block_ids / create_separate_requests present, asset_type / property_id present.
+
+NOT yet verified:
+- The backfill was not exercised on real data. maintenance_requests had 0 rows locally, so the "one unit asset per existing request" and property_id backfill checks passed vacuously. Worth re-checking against a database that actually has maintenance requests before this reaches staging.
+- The end-to-end API smoke test (8 cases in the plan: single unit, multi unit, block-only, fan-out, empty selection, cross-property asset, block filter, duplicate-match filter) has not been run. It needs a client-user JWT.
+
+Two fixes made beyond the plan:
+- internal/services/expense.go fetched the request with Populate ["Unit"] purely to read mr.Unit.PropertyID; now reads mr.PropertyID with the populate dropped.
+- Pre-existing bug in CreateByAdmin: the gorm.ErrRecordNotFound branch set INTERNAL_ONLY then returned InternalServerError regardless, so a unit with no active lease produced a 500 instead of downgrading. Now downgrades as intended.
+
+Unrelated blocker fixed to get migrations running at all — see RENTL-49.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/rentl-48.2 - Analytics-—-update-Cube.js-maintenance-schema-for-the-asset-model.md
+++ b/backlog/tasks/rentl-48.2 - Analytics-—-update-Cube.js-maintenance-schema-for-the-asset-model.md
@@ -1,0 +1,61 @@
+---
+id: RENTL-48.2
+title: Analytics — update Cube.js maintenance schema for the asset model
+status: In Progress
+assignee: []
+created_date: '2026-08-01 14:19'
+updated_date: '2026-08-01 15:06'
+labels:
+  - maintenance-requests
+  - analytics
+dependencies:
+  - RENTL-48.1
+references:
+  - services/cube/model/cubes/MaintenanceRequests.js
+  - apps/property-manager/app/modules/insights/overview/risk-summary.tsx
+  - apps/pm_mobile/lib/src/lib/activity_counts_logic.dart
+documentation:
+  - docs/superpowers/specs/2026-08-01-maintenance-request-multi-asset-design.md
+parent_task_id: RENTL-48
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The Cube.js maintenance schema reads the database directly and joins units on mr.unit_id to reach the property, then derives its row-level property security scope from that join. When RENTL-48.1 drops the unit_id column, maintenance analytics break outright — including access control, not just display.
+
+Critical rollout note: because Cube reads the database directly, it breaks the moment the migration runs, regardless of API deploy order. This must ship together with the migration, not after it.
+
+The denormalized property_id added in RENTL-48.1 makes this a simplification rather than extra work — see the Analytics section of docs/superpowers/specs/2026-08-01-maintenance-request-multi-asset-design.md for the exact diff.
+
+The unitId dimension is to be removed rather than reworked: a request no longer has one unit, and the dimension is unused. The only consumers of this cube are the portal insights overview and the pm_mobile activity counts, both of which read status counts and propertyId only. Unit-level maintenance analytics, if wanted later, belongs in a separate cube over the assets table.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The maintenance cube resolves its property without joining through units
+- [ ] #2 Row-level property scoping still restricts results to the caller's permitted properties, verified with a user who has access to a subset of properties
+- [ ] #3 The property dimension no longer runs a per-row correlated subquery
+- [ ] #4 The unused unit dimension is removed
+- [ ] #5 All existing maintenance measures are unchanged, and the portal insights overview and pm_mobile activity counts render the same numbers as before the migration
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implementation complete and unstaged.
+
+Verified:
+- node --test services/cube/model/ — 17/17 passing (scope.js helpers untouched but confirmed still correct).
+- yarn --cwd services/cube check:schema — schema compiles, all 8 cubes present including MaintenanceRequests. NOTE: this requires Node 20+; the default shell Node here is 18.20.8 and fails with "Cube.js CLI requires Node.js 20 or higher". Ran it under nvm v22.19.0.
+- Row-level scoping verified directly against the migrated schema, in a rolled-back transaction with one maintenance request per property: OWNER saw all 3 properties of their client; the same user demoted to STAFF (holding a single client_user_properties grant) saw exactly 1; a different client saw 0. Rollback left no residue and the role was restored.
+- The cube's base SQL executes against the migrated schema, which is the real regression risk — it proves no reference to the dropped unit_id column remains.
+
+NOT verified:
+- The dashboards were not rendered visually. The Insights overview and pm_mobile activity counts were not opened in a browser/simulator. Evidence that they are unaffected is indirect but strong: no measure definition was touched, the propertyId dimension keeps its name and type, and the compile check passes. Worth a quick visual pass before release.
+
+Changes are confined to services/cube/model/cubes/MaintenanceRequests.js: units join removed, scope predicate reads mr.property_id, propertyId dimension drops its per-row correlated subquery, unused unitId dimension removed.
+
+RELEASE CONSTRAINT: this must ship in the same release as the RENTL-48.1 migration. Cube reads the database directly, so it breaks the moment unit_id is dropped, regardless of API deploy order.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/rentl-48.3 - Property-manager-portal-—-multi-asset-create-form-and-read-surfaces.md
+++ b/backlog/tasks/rentl-48.3 - Property-manager-portal-—-multi-asset-create-form-and-read-surfaces.md
@@ -1,0 +1,85 @@
+---
+id: RENTL-48.3
+title: Property manager portal — multi-asset create form and read surfaces
+status: In Progress
+assignee: []
+created_date: '2026-08-01 14:20'
+updated_date: '2026-08-01 15:18'
+labels:
+  - maintenance-requests
+  - frontend
+dependencies:
+  - RENTL-48.1
+references:
+  - >-
+    apps/property-manager/app/modules/properties/property/activities/maintenance-requests/new/index.tsx
+  - >-
+    apps/property-manager/app/modules/properties/property/activities/maintenance-requests/request-card.tsx
+  - >-
+    apps/property-manager/app/modules/properties/property/activities/maintenance-requests/request/sidebar.tsx
+  - >-
+    apps/property-manager/app/modules/properties/property/activities/maintenance-requests/controller.tsx
+  - apps/property-manager/app/api/maintenance-requests/index.ts
+  - apps/property-manager/app/components/multi-select.tsx
+  - apps/property-manager/types/maintenance.d.ts
+documentation:
+  - docs/superpowers/specs/2026-08-01-maintenance-request-multi-asset-design.md
+parent_task_id: RENTL-48
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replace the single-unit select on the maintenance request create form with independent block and unit multi-selects, add the fan-out option, and update every surface that displays or filters by the old single unit.
+
+See the "Frontend — Property Manager Portal" section of docs/superpowers/specs/2026-08-01-maintenance-request-multi-asset-design.md for the form layout and the per-file change list.
+
+Notes for whoever picks this up:
+- No new UI primitives are needed. MultiSelect already exists at app/components/multi-select.tsx with option-group support, and useGetPropertyBlocks already exists in app/api/blocks.
+- Blocks and units are fully independent. Selecting a block and a unit inside that same block is legitimate and must not be blocked or warned about.
+- The landlord must understand before submitting that a block or a multi-unit selection makes the request invisible to tenants, and that fan-out is the way to keep tenants notified.
+- The unit detail maintenance tab needs no change; it filters by unit, which keeps working.
+- While in types/maintenance.d.ts, remove the duplicated metadata key on MaintenanceRequestActivityLog.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The create form offers independent block and unit multi-selects, with units grouped by block, and selecting a block plus a unit inside it is allowed
+- [ ] #2 The form cannot be submitted with no block and no unit selected
+- [ ] #3 When the selection forces internal-only, the form says so before submission and the visibility control is disabled
+- [ ] #4 The fan-out option appears once two or more assets are selected, is off by default, and explains that it creates one request per asset
+- [ ] #5 After creating a single request the user lands on that request's detail page; after a fan-out the user lands on the list with the created count surfaced
+- [ ] #6 The Kanban card and the request detail sidebar show all of a request's assets, with links to each unit and block
+- [ ] #7 The list can be filtered by block as well as by unit
+- [ ] #8 The unit detail maintenance tab still lists that unit's requests
+- [ ] #9 The new form and asset displays are verified in both light and dark modes
+- [ ] #10 yarn types:check and yarn lint pass
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implementation complete and unstaged.
+
+Verified:
+- yarn types:check exit 0, yarn lint exit 0 (none of the changed files appear in lint output), yarn build exit 0.
+- NOTE: all three require Node 20+. The default shell Node here is 18.20.8 and types:check fails with "TypeError: crypto.hash is not a function". Ran under nvm v22.19.0. Check CI pins >= 20.
+
+Changed:
+- types/maintenance.d.ts — MaintenanceRequestAsset added; unit_id/unit replaced by property_id/property/assets; block_id added to the fetch filter; removed the duplicated metadata key on MaintenanceRequestActivityLog.
+- api/maintenance-requests/index.ts — create input takes unit_ids / block_ids / create_separate_requests; create response typed as MaintenanceRequest[].
+- api/maintenance-requests/server.ts — detail populate now Assets,Assets.Unit,Assets.PropertyBlock.
+- activities/maintenance-requests/new/index.tsx — two independent MultiSelects (blocks, and units grouped by block), fan-out Switch shown at 2+ assets and defaulting off, live forced-internal banner, Visibility select disabled when forced, superRefine requiring at least one asset, post-create navigation branching on array length.
+- activities/maintenance-requests/request-card.tsx — asset chip ("Block A", "A1 +2").
+- activities/maintenance-requests/request/sidebar.tsx — one row per asset; unit rows link to the unit, block rows link to the blocks list (no block detail route exists).
+- activities/maintenance-requests/index.tsx — list populate switched to the asset relations; block_id passed through.
+- activities/maintenance-requests/controller.tsx — Block filter (selectType multi, urlParam "block"). Unit filter deliberately left on single.
+
+Two things beyond the plan:
+- The plan missed app/modules/insights/overview/risk-detail-modal.tsx, which read request.unit.property_id / unit.property.name / unit.name. It now reads request.property_id, request.property.name, and an assetSummary() of the assets, and its populate changed from ['Unit','Unit.Property'] to ['Property','Assets','Assets.Unit','Assets.PropertyBlock'].
+- That required a small backend addition: the admin transformation now emits "property" (DBPropertyToRest, which already guards nil/uuid.Nil) alongside property_id, and OutputProperty was added to the swagger struct. Swagger regenerated. This is in services/main/internal/transformations/maintenance-request.go and is NOT part of commit d3953228.
+
+NOT verified:
+- No browser verification. The 8 create-form cases, the asset chips/sidebar rendering, the block filter behaviour, and dark mode were all checked by types/lint/build only. Running them needs the API plus a client-user login, which I do not have. This is the remaining work before the task can close.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/rentl-48.4 - pm_mobile-—-read-maintenance-assets-instead-of-a-single-unit.md
+++ b/backlog/tasks/rentl-48.4 - pm_mobile-—-read-maintenance-assets-instead-of-a-single-unit.md
@@ -1,0 +1,78 @@
+---
+id: RENTL-48.4
+title: pm_mobile — read maintenance assets instead of a single unit
+status: In Progress
+assignee: []
+created_date: '2026-08-01 14:20'
+updated_date: '2026-08-01 15:28'
+labels:
+  - maintenance-requests
+  - mobile
+dependencies:
+  - RENTL-48.1
+references:
+  - apps/pm_mobile/lib/src/repository/models/maintenance_request_model.dart
+  - apps/pm_mobile/lib/src/api/maintenance_request_api.dart
+  - apps/pm_mobile/lib/src/modules/main/activity/maintenance_detail.dart
+  - apps/pm_mobile/lib/src/modules/main/activity/maintenance_board.dart
+documentation:
+  - docs/superpowers/specs/2026-08-01-maintenance-request-multi-asset-design.md
+parent_task_id: RENTL-48
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The pm_mobile maintenance request model declares unit_id as required and non-nullable, so this app hard-breaks on deserialization the moment RENTL-48.1 removes the field from API responses. The detail and board screens also navigate using request.unit.propertyId and request.unitId, which stop resolving.
+
+Scope correction made while planning: this task was originally written to also add a multi-asset create form. It cannot, because pm_mobile has no create feature to extend. add_maintenance.dart is a static mockup — its unit picker reads a hardcoded _kUnits list of fake names, the "Create request" button only fires a haptic, and maintenance_request_api.dart has no POST method at all. Building real creation is a separate feature, tracked as RENTL-48.6.
+
+This task is therefore the break-fix only: read the asset list, render it, and keep navigation working.
+
+See the "Flutter — pm_mobile" section of docs/superpowers/specs/2026-08-01-maintenance-request-multi-asset-design.md.
+
+Note: build_runner dirties unrelated .g.dart files and project.pbxproj. Revert unrelated churn before handing off.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Maintenance request screens load without deserialization errors against the new API
+- [ ] #2 The request detail screen shows all of a request's assets rather than a single unit
+- [ ] #3 Tapping a unit asset still navigates to that unit's page, using the property from the request rather than from the unit
+- [ ] #4 The board screen renders and navigates correctly for requests with any number of assets, including a block-only request with no unit
+- [ ] #5 Nothing crashes or renders blank for a request whose assets list is empty or contains only blocks
+- [ ] #6 Unrelated generated-file churn is reverted before handoff
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implementation complete and unstaged.
+
+Verified:
+- flutter analyze: 0 errors (remaining infos are pre-existing deprecated_member_use in generated Riverpod files and curly_braces lints elsewhere).
+- flutter test: 212/212 passing.
+
+Changed:
+- models/maintenance_request_model.dart — MaintenanceBlockModel and MaintenanceAssetModel added (assetType discriminator, nullable unit/propertyBlock, label getter with type fallback). unitId/unit replaced by propertyId (non-nullable) and assets. Added unitAssets, blockAssets, and assetSummary getters.
+- api/maintenance_request_api.dart — both _populate and _detailPopulate now request Assets,Assets.Unit,Assets.PropertyBlock instead of Unit. Stale doc comment about reading propertyId from the nested unit corrected.
+- activity/maintenance_detail.dart — _PropertiesCard renders one row per asset (units link to the unit; blocks link to the property's blocks list, since no block detail route exists) and takes the property from the request.
+- activity/maintenance_board.dart — card subtitle uses assetSummary; navigation extra uses m.propertyId.
+
+Four sites beyond the plan, all reading .unit?.propertyId purely to reach the property — each now uses the non-nullable request.propertyId:
+- maintenance_board.dart _refreshAssigneeSources()
+- notifiers/activity/maintenance_request_status_notifier.dart — this one was a latent bug: status updates failed outright when the unit relation was not populated. Now it cannot.
+- providers/activity/maintenance_detail_provider.dart
+- board card subtitle (was m.unit?.name)
+
+Tests updated and extended (the plan did not account for pm_mobile having a test suite):
+- test/modules/main/activity/maintenance_detail_test.dart — fixture rebuilt around propertyId + a UNIT asset.
+- test/api/maintenance_request_api_test.dart — fixture and populate expectations updated to the asset relations.
+- test/repository/models/maintenance_detail_models_test.dart — fixtures updated, plus three new cases: a multi-unit-plus-block request (asserts unitAssets/blockAssets split and "A1 +2" summary), an unpopulated relation falling back to the asset-type label, and a payload with no assets key at all rendering "—" rather than throwing.
+
+Codegen hygiene: build_runner rewrote 7 unrelated .g.dart files with formatting-only churn from a differing formatter version. All 7 reverted; analyze and the full suite still pass, confirming they were unnecessary. Only maintenance_request_model.g.dart remains, and its diff is purely the additive block/asset serializers. No project.pbxproj churn.
+
+NOT verified:
+- Nothing run on a simulator. Per project convention I did not launch the app. The six on-device checks in the plan (single-unit, multi-unit, block-only, mixed, board navigation, divider placement on the last row) still need a human pass.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/rentl-48.5 - Tenant-app-apps-go-—-read-maintenance-assets-instead-of-a-single-unit.md
+++ b/backlog/tasks/rentl-48.5 - Tenant-app-apps-go-—-read-maintenance-assets-instead-of-a-single-unit.md
@@ -1,0 +1,69 @@
+---
+id: RENTL-48.5
+title: Tenant app (apps/go) — read maintenance assets instead of a single unit
+status: In Progress
+assignee: []
+created_date: '2026-08-01 14:20'
+updated_date: '2026-08-01 15:40'
+labels:
+  - maintenance-requests
+  - mobile
+dependencies:
+  - RENTL-48.1
+references:
+  - apps/go/lib/src/repository/models/maintenance_request_model.dart
+  - apps/go/lib/src/modules/main/maintenance_details/root.dart
+  - apps/go/lib/src/modules/main/maintenance/request_card.dart
+  - apps/go/lib/src/modules/main/new_maintenance/root.dart
+documentation:
+  - docs/superpowers/specs/2026-08-01-maintenance-request-multi-asset-design.md
+parent_task_id: RENTL-48
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The tenant app declares unit_id and unit on its maintenance request model, but never reads either one — no maintenance screen displays the unit. Both fields are already nullable, so when RENTL-48.1 stops sending them, json_serializable simply leaves them null and nothing breaks.
+
+Scope correction made while planning: this task was originally written as a fix. It is not — the app keeps working untouched. What remains is removing the two now-dead fields so the model stops advertising data the API no longer returns, which would otherwise mislead the next person to read it.
+
+Do not add an assets field. The tenant app never displays assets, and tenant-visible requests are always single-unit by design. Adding one would be speculative.
+
+The tenant create flow is unchanged: it posts to the lease-scoped endpoint and never selects a unit.
+
+Note: build_runner dirties unrelated .g.dart files and project.pbxproj. Revert unrelated churn before handing off.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The dead unitId and unit fields are removed from the maintenance request model, along with MaintenanceUnitModel if nothing else uses it
+- [ ] #2 Generated serialization code is regenerated and the app compiles
+- [ ] #3 Maintenance list, detail, and stats screens render unchanged against the new API
+- [ ] #4 Creating a maintenance request from a lease still works unchanged
+- [ ] #5 Unrelated generated-file churn is reverted before handoff
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implementation complete and unstaged.
+
+Premise re-confirmed before touching anything: every reference to unitId / unit / MaintenanceUnitModel lived inside maintenance_request_model.dart itself. No screen read them. The maintenance API populate strings request only ActivityLogs, Expenses and Expenses.Invoices — this app never asked for the Unit relation, which is why it never displayed one. So nothing here was broken by the backend change, and no populate fix was needed (unlike pm_mobile, where both populate constants had to change).
+
+Changed:
+- lib/src/repository/models/maintenance_request_model.dart — removed the MaintenanceUnitModel class entirely, and the unitId / unit fields plus their constructor parameters from MaintenanceRequestModel.
+- Regenerated maintenance_request_model.g.dart; no unit references remain in generated code.
+- docs/changelog.md — dated entry appended, per this app's CLAUDE.md convention of updating the docs index after every change. docs/implementation.md needed no edit: it indexes API classes, notifiers and providers, not model fields, and names none of the removed symbols.
+
+Deliberately did NOT add an assets field. Tenant-visible requests are always single-unit by design and no screen renders assets, so it would be an unread field. Add it when a screen needs it.
+
+Verified:
+- flutter analyze: 0 errors (49 remaining infos are pre-existing deprecation and lint noise elsewhere).
+- No test run: this app has no test harness configured (per apps/go/CLAUDE.md).
+
+Codegen hygiene: build_runner also rewrote create_offline_payment_notifier.g.dart (source-hash line only) and invoices_provider.g.dart (formatting). Both reverted; analyze still clean. Final diff is two files plus the changelog. No project.pbxproj churn.
+
+NOT verified:
+- Not run on a simulator. Per project convention I did not launch the app. A quick pass over the maintenance list, detail and home stats card against the migrated API would confirm nothing regressed, though the risk is very low given the fields were unused.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/rentl-48.6 - pm_mobile-—-build-real-maintenance-request-creation-multi-asset.md
+++ b/backlog/tasks/rentl-48.6 - pm_mobile-—-build-real-maintenance-request-creation-multi-asset.md
@@ -1,0 +1,53 @@
+---
+id: RENTL-48.6
+title: pm_mobile — build real maintenance request creation (multi-asset)
+status: To Do
+assignee: []
+created_date: '2026-08-01 14:31'
+labels:
+  - maintenance-requests
+  - mobile
+dependencies:
+  - RENTL-48.1
+  - RENTL-48.4
+references:
+  - apps/pm_mobile/lib/src/modules/main/activity/add_maintenance.dart
+  - apps/pm_mobile/lib/src/api/maintenance_request_api.dart
+  - apps/pm_mobile/lib/src/navigation/routes.dart
+documentation:
+  - docs/superpowers/specs/2026-08-01-maintenance-request-multi-asset-design.md
+parent_task_id: RENTL-48
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Discovered while planning RENTL-48.4: pm_mobile cannot actually create maintenance requests. The screen at apps/pm_mobile/lib/src/modules/main/activity/add_maintenance.dart is a static mockup — its unit picker reads a hardcoded _kUnits list of fake unit names, its "Create request" button only fires a haptic and calls no API, and apps/pm_mobile/lib/src/api/maintenance_request_api.dart has no POST method at all.
+
+This task is to make that screen real, built multi-asset from the start so there is no second migration: multi-select blocks and units loaded from the API, the fan-out option, and the internal-only warning, matching the property manager portal.
+
+This is NOT required to release RENTL-48. The multi-asset feature ships on the web portal; this brings mobile to parity afterwards. Do it after RENTL-48.4 has landed the model changes it depends on.
+
+Behaviour to match (see docs/superpowers/specs/2026-08-01-maintenance-request-multi-asset-design.md):
+- Blocks and units are independent selections; selecting a block plus a unit inside it is allowed.
+- Any block, or more than one asset, forces the request to internal-only and notifies no tenant. Tell the user before they submit.
+- Fan-out creates one request per selected asset, so each unit request can still notify its tenant.
+- The create endpoint returns an array of created requests.
+
+Follow the app's existing conventions: shimmer skeleton loaders rather than spinners, and pull-to-refresh on list and detail screens.
+
+Note: build_runner dirties unrelated .g.dart files and project.pbxproj. Revert unrelated churn before handing off.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The create screen loads real blocks and units for the selected property from the API, replacing the hardcoded placeholder list
+- [ ] #2 A property manager can select multiple blocks and multiple units independently and submit, and a request is actually created
+- [ ] #3 The form cannot be submitted with no asset selected
+- [ ] #4 The form states that the request will be internal-only when a block or more than one asset is selected
+- [ ] #5 The fan-out option is offered and creates one request per selected asset
+- [ ] #6 Submission failures surface an error to the user rather than failing silently
+- [ ] #7 New and changed screens use shimmer skeleton loaders and support pull-to-refresh, consistent with the rest of the app
+- [ ] #8 Unrelated generated-file churn is reverted before handoff
+<!-- AC:END -->

--- a/backlog/tasks/rentl-49 - Make-SplitSessionsFromRefreshTokens-migration-idempotent.md
+++ b/backlog/tasks/rentl-49 - Make-SplitSessionsFromRefreshTokens-migration-idempotent.md
@@ -1,0 +1,38 @@
+---
+id: RENTL-49
+title: Make SplitSessionsFromRefreshTokens migration idempotent
+status: To Do
+assignee: []
+created_date: '2026-08-01 14:57'
+labels:
+  - backend
+  - migrations
+dependencies: []
+references:
+  - services/main/init/migration/jobs/split-sessions-from-refresh-tokens.go
+  - services/main/internal/models/refresh-token.go
+  - services/main/internal/models/session.go
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found while running migrations for RENTL-48.1. This migration blocks every later migration on any database that already ran its earlier version.
+
+The job in code carries ID 202607310001_SPLIT_SESSIONS_FROM_REFRESH_TOKENS_V2, but databases that ran the original have 202607300001_SPLIT_SESSIONS_FROM_REFRESH_TOKENS recorded — and no job in the codebase uses that older ID. gormigrate therefore treats V2 as never applied and re-runs it, where it dies on "column r.user_id does not exist" because the earlier run already dropped that column. Because gormigrate halts on the first failure, every subsequent migration is blocked behind it.
+
+This was observed on a local database restored from a dump (rentloop_dump). Any environment whose migrations table has the 202607300001 id will fail the same way on its next deploy — staging and production should be checked.
+
+Fix applied: a guard at the top of Migrate counts refresh_tokens.user_id in information_schema.columns and returns nil when it is absent. The absence of that column is the completion marker, since step 5 of the migration is what drops it. This also correctly no-ops on a brand-new database, where AutoMigrate builds refresh_tokens straight from models.RefreshToken, which has no UserID.
+
+Verified locally: migrations now run to completion.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Running migrations against a database that already applied the original 202607300001 version completes without error
+- [ ] #2 Running migrations against a brand-new database still produces the correct sessions and refresh_tokens shape
+- [ ] #3 Running migrations against a database that has neither version applied still performs the full session backfill
+- [ ] #4 Staging and production migrations tables are checked for the 202607300001 id, and the outcome is recorded on this task
+<!-- AC:END -->

--- a/services/cube/model/cubes/MaintenanceRequests.js
+++ b/services/cube/model/cubes/MaintenanceRequests.js
@@ -1,21 +1,24 @@
 import { propertyScopeSql } from './scope';
 
 /**
- * MaintenanceRequests cube — scoped to the authenticated client via
- * properties, then narrowed to the caller's permitted properties (see
- * `../scope.js`).
+ * MaintenanceRequests cube — scoped to the authenticated client via the
+ * request's own property_id, then narrowed to the caller's permitted
+ * properties (see `../scope.js`).
+ *
+ * A request can target many units and blocks, so it no longer has a single
+ * unit. Unit-level maintenance analytics would need its own cube over
+ * `maintenance_request_assets`.
  */
 cube(`MaintenanceRequests`, {
   sql: `
     SELECT mr.*
     FROM maintenance_requests mr
-    JOIN units u ON u.id = mr.unit_id AND u.deleted_at IS NULL
-    JOIN properties p ON p.id = u.property_id AND p.deleted_at IS NULL
+    JOIN properties p ON p.id = mr.property_id AND p.deleted_at IS NULL
     WHERE mr.deleted_at IS NULL
       AND ${COMPILE_CONTEXT.securityContext?.clientId
         ? `p.client_id = '${COMPILE_CONTEXT.securityContext.clientId}'::uuid`
         : '1 = 0'}
-      AND ${propertyScopeSql(COMPILE_CONTEXT.securityContext, 'u.property_id::text')}
+      AND ${propertyScopeSql(COMPILE_CONTEXT.securityContext, 'mr.property_id::text')}
   `,
 
   measures: {
@@ -89,15 +92,9 @@ cube(`MaintenanceRequests`, {
     },
 
     propertyId: {
-      sql: `(SELECT u.property_id::text FROM units u WHERE u.id = ${CUBE}.unit_id LIMIT 1)`,
+      sql: `property_id`,
       type: `string`,
       title: `Property ID`,
-    },
-
-    unitId: {
-      sql: `unit_id`,
-      type: `string`,
-      title: `Unit ID`,
     },
 
     tenantId: {

--- a/services/main/docs/docs.go
+++ b/services/main/docs/docs.go
@@ -3912,6 +3912,15 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "name": "block_id",
+                        "in": "query"
+                    },
+                    {
                         "type": "string",
                         "name": "category",
                         "in": "query"
@@ -10819,6 +10828,15 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "name": "block_id",
+                        "in": "query"
+                    },
+                    {
                         "type": "string",
                         "name": "category",
                         "in": "query"
@@ -10978,7 +10996,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Create a new maintenance request (Admin)",
+                "description": "Create maintenance request(s) against one or more units and/or blocks (Admin).\nAlways responds with an array: one request normally, or one per selected asset\nwhen create_separate_requests is true. A request covering more than one asset,\nor any block, is forced to INTERNAL_ONLY.",
                 "consumes": [
                     "application/json"
                 ],
@@ -10988,7 +11006,7 @@ const docTemplate = `{
                 "tags": [
                     "MaintenanceRequests"
                 ],
-                "summary": "Create a maintenance request (Admin)",
+                "summary": "Create maintenance request(s) (Admin)",
                 "parameters": [
                     {
                         "type": "string",
@@ -11009,12 +11027,15 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "201": {
-                        "description": "Maintenance request created successfully",
+                        "description": "Maintenance request(s) created successfully",
                         "schema": {
                             "type": "object",
                             "properties": {
                                 "data": {
-                                    "$ref": "#/definitions/transformations.AdminOutputMaintenanceRequest"
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/transformations.AdminOutputMaintenanceRequest"
+                                    }
                                 }
                             }
                         }
@@ -21589,7 +21610,6 @@ const docTemplate = `{
                 "description",
                 "priority",
                 "title",
-                "unit_id",
                 "visibility"
             ],
             "properties": {
@@ -21599,8 +21619,17 @@ const docTemplate = `{
                         "type": "string"
                     }
                 },
+                "block_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "category": {
                     "type": "string"
+                },
+                "create_separate_requests": {
+                    "type": "boolean"
                 },
                 "description": {
                     "type": "string"
@@ -21617,8 +21646,12 @@ const docTemplate = `{
                 "title": {
                     "type": "string"
                 },
-                "unit_id": {
-                    "type": "string"
+                "unit_ids": {
+                    "description": "At least one of UnitIDs / BlockIDs must be non-empty. That rule cannot be\nexpressed in struct tags, so the service enforces it.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "visibility": {
                     "type": "string",
@@ -24023,6 +24056,12 @@ const docTemplate = `{
                         "$ref": "#/definitions/transformations.OutputMaintenanceActivityLog"
                     }
                 },
+                "assets": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/transformations.OutputMaintenanceRequestAsset"
+                    }
+                },
                 "assigned_manager": {
                     "$ref": "#/definitions/transformations.OutputClientUser"
                 },
@@ -24086,6 +24125,9 @@ const docTemplate = `{
                 "priority": {
                     "type": "string"
                 },
+                "property_id": {
+                    "type": "string"
+                },
                 "resolved_at": {
                     "type": "string"
                 },
@@ -24099,12 +24141,6 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "title": {
-                    "type": "string"
-                },
-                "unit": {
-                    "$ref": "#/definitions/transformations.AdminOutputUnit"
-                },
-                "unit_id": {
                     "type": "string"
                 },
                 "updated_at": {
@@ -26368,6 +26404,12 @@ const docTemplate = `{
                         "$ref": "#/definitions/transformations.OutputMaintenanceActivityLog"
                     }
                 },
+                "assets": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/transformations.OutputMaintenanceRequestAsset"
+                    }
+                },
                 "attachments": {
                     "type": "array",
                     "items": {
@@ -26404,6 +26446,9 @@ const docTemplate = `{
                 "priority": {
                     "type": "string"
                 },
+                "property_id": {
+                    "type": "string"
+                },
                 "resolved_at": {
                     "type": "string"
                 },
@@ -26416,13 +26461,26 @@ const docTemplate = `{
                 "title": {
                     "type": "string"
                 },
-                "unit": {
-                    "$ref": "#/definitions/transformations.OutputUnit"
-                },
-                "unit_id": {
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "transformations.OutputMaintenanceRequestAsset": {
+            "type": "object",
+            "properties": {
+                "asset_type": {
                     "type": "string"
                 },
-                "updated_at": {
+                "id": {
+                    "type": "string"
+                },
+                "property_block": {},
+                "property_block_id": {
+                    "type": "string"
+                },
+                "unit": {},
+                "unit_id": {
                     "type": "string"
                 }
             }

--- a/services/main/docs/docs.go
+++ b/services/main/docs/docs.go
@@ -24125,6 +24125,9 @@ const docTemplate = `{
                 "priority": {
                     "type": "string"
                 },
+                "property": {
+                    "$ref": "#/definitions/transformations.OutputProperty"
+                },
                 "property_id": {
                     "type": "string"
                 },

--- a/services/main/docs/swagger.json
+++ b/services/main/docs/swagger.json
@@ -24117,6 +24117,9 @@
                 "priority": {
                     "type": "string"
                 },
+                "property": {
+                    "$ref": "#/definitions/transformations.OutputProperty"
+                },
                 "property_id": {
                     "type": "string"
                 },

--- a/services/main/docs/swagger.json
+++ b/services/main/docs/swagger.json
@@ -3904,6 +3904,15 @@
                         "in": "query"
                     },
                     {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "name": "block_id",
+                        "in": "query"
+                    },
+                    {
                         "type": "string",
                         "name": "category",
                         "in": "query"
@@ -10811,6 +10820,15 @@
                         "in": "query"
                     },
                     {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "name": "block_id",
+                        "in": "query"
+                    },
+                    {
                         "type": "string",
                         "name": "category",
                         "in": "query"
@@ -10970,7 +10988,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Create a new maintenance request (Admin)",
+                "description": "Create maintenance request(s) against one or more units and/or blocks (Admin).\nAlways responds with an array: one request normally, or one per selected asset\nwhen create_separate_requests is true. A request covering more than one asset,\nor any block, is forced to INTERNAL_ONLY.",
                 "consumes": [
                     "application/json"
                 ],
@@ -10980,7 +10998,7 @@
                 "tags": [
                     "MaintenanceRequests"
                 ],
-                "summary": "Create a maintenance request (Admin)",
+                "summary": "Create maintenance request(s) (Admin)",
                 "parameters": [
                     {
                         "type": "string",
@@ -11001,12 +11019,15 @@
                 ],
                 "responses": {
                     "201": {
-                        "description": "Maintenance request created successfully",
+                        "description": "Maintenance request(s) created successfully",
                         "schema": {
                             "type": "object",
                             "properties": {
                                 "data": {
-                                    "$ref": "#/definitions/transformations.AdminOutputMaintenanceRequest"
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/transformations.AdminOutputMaintenanceRequest"
+                                    }
                                 }
                             }
                         }
@@ -21581,7 +21602,6 @@
                 "description",
                 "priority",
                 "title",
-                "unit_id",
                 "visibility"
             ],
             "properties": {
@@ -21591,8 +21611,17 @@
                         "type": "string"
                     }
                 },
+                "block_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "category": {
                     "type": "string"
+                },
+                "create_separate_requests": {
+                    "type": "boolean"
                 },
                 "description": {
                     "type": "string"
@@ -21609,8 +21638,12 @@
                 "title": {
                     "type": "string"
                 },
-                "unit_id": {
-                    "type": "string"
+                "unit_ids": {
+                    "description": "At least one of UnitIDs / BlockIDs must be non-empty. That rule cannot be\nexpressed in struct tags, so the service enforces it.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "visibility": {
                     "type": "string",
@@ -24015,6 +24048,12 @@
                         "$ref": "#/definitions/transformations.OutputMaintenanceActivityLog"
                     }
                 },
+                "assets": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/transformations.OutputMaintenanceRequestAsset"
+                    }
+                },
                 "assigned_manager": {
                     "$ref": "#/definitions/transformations.OutputClientUser"
                 },
@@ -24078,6 +24117,9 @@
                 "priority": {
                     "type": "string"
                 },
+                "property_id": {
+                    "type": "string"
+                },
                 "resolved_at": {
                     "type": "string"
                 },
@@ -24091,12 +24133,6 @@
                     "type": "string"
                 },
                 "title": {
-                    "type": "string"
-                },
-                "unit": {
-                    "$ref": "#/definitions/transformations.AdminOutputUnit"
-                },
-                "unit_id": {
                     "type": "string"
                 },
                 "updated_at": {
@@ -26360,6 +26396,12 @@
                         "$ref": "#/definitions/transformations.OutputMaintenanceActivityLog"
                     }
                 },
+                "assets": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/transformations.OutputMaintenanceRequestAsset"
+                    }
+                },
                 "attachments": {
                     "type": "array",
                     "items": {
@@ -26396,6 +26438,9 @@
                 "priority": {
                     "type": "string"
                 },
+                "property_id": {
+                    "type": "string"
+                },
                 "resolved_at": {
                     "type": "string"
                 },
@@ -26408,13 +26453,26 @@
                 "title": {
                     "type": "string"
                 },
-                "unit": {
-                    "$ref": "#/definitions/transformations.OutputUnit"
-                },
-                "unit_id": {
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "transformations.OutputMaintenanceRequestAsset": {
+            "type": "object",
+            "properties": {
+                "asset_type": {
                     "type": "string"
                 },
-                "updated_at": {
+                "id": {
+                    "type": "string"
+                },
+                "property_block": {},
+                "property_block_id": {
+                    "type": "string"
+                },
+                "unit": {},
+                "unit_id": {
                     "type": "string"
                 }
             }

--- a/services/main/docs/swagger.yaml
+++ b/services/main/docs/swagger.yaml
@@ -2672,6 +2672,8 @@ definitions:
         type: string
       priority:
         type: string
+      property:
+        $ref: '#/definitions/transformations.OutputProperty'
       property_id:
         type: string
       resolved_at:

--- a/services/main/docs/swagger.yaml
+++ b/services/main/docs/swagger.yaml
@@ -856,8 +856,14 @@ definitions:
         items:
           type: string
         type: array
+      block_ids:
+        items:
+          type: string
+        type: array
       category:
         type: string
+      create_separate_requests:
+        type: boolean
       description:
         type: string
       priority:
@@ -869,8 +875,13 @@ definitions:
         type: string
       title:
         type: string
-      unit_id:
-        type: string
+      unit_ids:
+        description: |-
+          At least one of UnitIDs / BlockIDs must be non-empty. That rule cannot be
+          expressed in struct tags, so the service enforces it.
+        items:
+          type: string
+        type: array
       visibility:
         enum:
         - TENANT_VISIBLE
@@ -881,7 +892,6 @@ definitions:
     - description
     - priority
     - title
-    - unit_id
     - visibility
     type: object
   handlers.CreateOfflinePaymentRequest:
@@ -2616,6 +2626,10 @@ definitions:
         items:
           $ref: '#/definitions/transformations.OutputMaintenanceActivityLog'
         type: array
+      assets:
+        items:
+          $ref: '#/definitions/transformations.OutputMaintenanceRequestAsset'
+        type: array
       assigned_manager:
         $ref: '#/definitions/transformations.OutputClientUser'
       assigned_manager_id:
@@ -2658,6 +2672,8 @@ definitions:
         type: string
       priority:
         type: string
+      property_id:
+        type: string
       resolved_at:
         type: string
       reviewed_at:
@@ -2667,10 +2683,6 @@ definitions:
       status:
         type: string
       title:
-        type: string
-      unit:
-        $ref: '#/definitions/transformations.AdminOutputUnit'
-      unit_id:
         type: string
       updated_at:
         type: string
@@ -4313,6 +4325,10 @@ definitions:
         items:
           $ref: '#/definitions/transformations.OutputMaintenanceActivityLog'
         type: array
+      assets:
+        items:
+          $ref: '#/definitions/transformations.OutputMaintenanceRequestAsset'
+        type: array
       attachments:
         items:
           type: string
@@ -4337,6 +4353,8 @@ definitions:
         type: string
       priority:
         type: string
+      property_id:
+        type: string
       resolved_at:
         type: string
       started_at:
@@ -4345,11 +4363,20 @@ definitions:
         type: string
       title:
         type: string
-      unit:
-        $ref: '#/definitions/transformations.OutputUnit'
-      unit_id:
-        type: string
       updated_at:
+        type: string
+    type: object
+  transformations.OutputMaintenanceRequestAsset:
+    properties:
+      asset_type:
+        type: string
+      id:
+        type: string
+      property_block: {}
+      property_block_id:
+        type: string
+      unit: {}
+      unit_id:
         type: string
     type: object
   transformations.OutputMaintenanceRequestComment:
@@ -7707,6 +7734,12 @@ paths:
       - in: query
         name: assigned_worker_id
         type: string
+      - collectionFormat: multi
+        in: query
+        items:
+          type: string
+        name: block_id
+        type: array
       - in: query
         name: category
         type: string
@@ -12058,6 +12091,12 @@ paths:
       - in: query
         name: assigned_worker_id
         type: string
+      - collectionFormat: multi
+        in: query
+        items:
+          type: string
+        name: block_id
+        type: array
       - in: query
         name: category
         type: string
@@ -12166,7 +12205,11 @@ paths:
     post:
       consumes:
       - application/json
-      description: Create a new maintenance request (Admin)
+      description: |-
+        Create maintenance request(s) against one or more units and/or blocks (Admin).
+        Always responds with an array: one request normally, or one per selected asset
+        when create_separate_requests is true. A request covering more than one asset,
+        or any block, is forced to INTERNAL_ONLY.
       parameters:
       - description: Property ID
         in: path
@@ -12183,11 +12226,13 @@ paths:
       - application/json
       responses:
         "201":
-          description: Maintenance request created successfully
+          description: Maintenance request(s) created successfully
           schema:
             properties:
               data:
-                $ref: '#/definitions/transformations.AdminOutputMaintenanceRequest'
+                items:
+                  $ref: '#/definitions/transformations.AdminOutputMaintenanceRequest'
+                type: array
             type: object
         "400":
           description: Error occurred when creating maintenance request
@@ -12207,7 +12252,7 @@ paths:
             type: string
       security:
       - BearerAuth: []
-      summary: Create a maintenance request (Admin)
+      summary: Create maintenance request(s) (Admin)
       tags:
       - MaintenanceRequests
   /api/v1/admin/clients/{client_id}/properties/{property_id}/maintenance-requests/{maintenance_request_id}:

--- a/services/main/init/migration/jobs/add-maintenance-request-assets.go
+++ b/services/main/init/migration/jobs/add-maintenance-request-assets.go
@@ -1,0 +1,119 @@
+package jobs
+
+import (
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+// AddMaintenanceRequestAssets replaces the single unit_id foreign key on
+// maintenance requests with a maintenance_request_assets join table, and
+// denormalizes property_id onto the request so property scoping and client-user
+// access control do not have to reach through units on every query.
+func AddMaintenanceRequestAssets() *gormigrate.Migration {
+	return &gormigrate.Migration{
+		ID: "202608010001_ADD_MAINTENANCE_REQUEST_ASSETS",
+		Migrate: func(db *gorm.DB) error {
+			return db.Transaction(func(tx *gorm.DB) error {
+				statements := []string{
+					`CREATE TABLE IF NOT EXISTS maintenance_request_assets (
+						id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+						created_at TIMESTAMPTZ,
+						updated_at TIMESTAMPTZ,
+						deleted_at TIMESTAMPTZ,
+						maintenance_request_id UUID NOT NULL REFERENCES maintenance_requests(id),
+						asset_type TEXT NOT NULL,
+						unit_id UUID REFERENCES units(id),
+						property_block_id UUID REFERENCES property_blocks(id)
+					)`,
+
+					`CREATE INDEX IF NOT EXISTS idx_mra_request
+						ON maintenance_request_assets (maintenance_request_id)`,
+					`CREATE INDEX IF NOT EXISTS idx_mra_asset_type
+						ON maintenance_request_assets (asset_type)`,
+					`CREATE INDEX IF NOT EXISTS idx_mra_deleted_at
+						ON maintenance_request_assets (deleted_at)`,
+
+					// The Go type cannot express "exactly one FK, matching the
+					// discriminator", so the database enforces it.
+					`ALTER TABLE maintenance_request_assets
+						DROP CONSTRAINT IF EXISTS chk_mra_asset_type`,
+					`ALTER TABLE maintenance_request_assets
+						ADD CONSTRAINT chk_mra_asset_type CHECK (
+							(asset_type = 'UNIT'  AND unit_id IS NOT NULL AND property_block_id IS NULL)
+							OR
+							(asset_type = 'BLOCK' AND property_block_id IS NOT NULL AND unit_id IS NULL)
+						)`,
+
+					// Partial so soft-deleted rows do not block re-adding an
+					// asset, and so each index only covers its own asset type.
+					`CREATE UNIQUE INDEX IF NOT EXISTS idx_mra_request_unit
+						ON maintenance_request_assets (maintenance_request_id, unit_id)
+						WHERE unit_id IS NOT NULL AND deleted_at IS NULL`,
+					`CREATE UNIQUE INDEX IF NOT EXISTS idx_mra_request_block
+						ON maintenance_request_assets (maintenance_request_id, property_block_id)
+						WHERE property_block_id IS NOT NULL AND deleted_at IS NULL`,
+
+					`ALTER TABLE maintenance_requests ADD COLUMN IF NOT EXISTS property_id UUID`,
+
+					// Backfill: one UNIT asset per existing request.
+					`INSERT INTO maintenance_request_assets
+						(id, created_at, updated_at, maintenance_request_id, asset_type, unit_id)
+					 SELECT uuid_generate_v4(), NOW(), NOW(), mr.id, 'UNIT', mr.unit_id
+					 FROM maintenance_requests mr
+					 WHERE mr.unit_id IS NOT NULL
+					   AND NOT EXISTS (
+						 SELECT 1 FROM maintenance_request_assets a
+						 WHERE a.maintenance_request_id = mr.id AND a.unit_id = mr.unit_id
+					   )`,
+
+					`UPDATE maintenance_requests mr
+					 SET property_id = u.property_id
+					 FROM units u
+					 WHERE u.id = mr.unit_id AND mr.property_id IS NULL`,
+
+					`ALTER TABLE maintenance_requests ALTER COLUMN property_id SET NOT NULL`,
+					`CREATE INDEX IF NOT EXISTS idx_mr_property_id
+						ON maintenance_requests (property_id)`,
+
+					`ALTER TABLE maintenance_requests DROP COLUMN IF EXISTS unit_id`,
+				}
+
+				for _, statement := range statements {
+					if err := tx.Exec(statement).Error; err != nil {
+						return err
+					}
+				}
+				return nil
+			})
+		},
+		Rollback: func(db *gorm.DB) error {
+			// Lossy by design: a genuinely multi-asset request collapses back to
+			// its first unit, and a block-only request is left without a unit.
+			// This exists for local rollback, not production reversal.
+			return db.Transaction(func(tx *gorm.DB) error {
+				statements := []string{
+					`ALTER TABLE maintenance_requests ADD COLUMN IF NOT EXISTS unit_id UUID`,
+					`UPDATE maintenance_requests mr
+					 SET unit_id = (
+						 SELECT a.unit_id FROM maintenance_request_assets a
+						 WHERE a.maintenance_request_id = mr.id
+						   AND a.asset_type = 'UNIT'
+						   AND a.deleted_at IS NULL
+						 ORDER BY a.created_at
+						 LIMIT 1
+					 )`,
+					`DROP TABLE IF EXISTS maintenance_request_assets`,
+					`DROP INDEX IF EXISTS idx_mr_property_id`,
+					`ALTER TABLE maintenance_requests DROP COLUMN IF EXISTS property_id`,
+				}
+
+				for _, statement := range statements {
+					if err := tx.Exec(statement).Error; err != nil {
+						return err
+					}
+				}
+				return nil
+			})
+		},
+	}
+}

--- a/services/main/init/migration/jobs/split-sessions-from-refresh-tokens.go
+++ b/services/main/init/migration/jobs/split-sessions-from-refresh-tokens.go
@@ -28,6 +28,30 @@ func SplitSessionsFromRefreshTokens() *gormigrate.Migration {
 			// The sessions table itself is created by AutoMigrate from the
 			// models.Session struct, which runs before these jobs.
 
+			// 0. Bail out if the split has already happened.
+			//
+			//    Two ways a database arrives here already in the target shape:
+			//    it ran this migration under its previous ID
+			//    (202607300001_SPLIT_SESSIONS_FROM_REFRESH_TOKENS, before the
+			//    ID was bumped to _V2), or it is brand new and AutoMigrate
+			//    built refresh_tokens straight from models.RefreshToken, which
+			//    no longer has UserID.
+			//
+			//    In both cases the body below would fail on refresh_tokens.user_id
+			//    — the very column step 5 drops — and take every later migration
+			//    down with it. The absence of that column IS the completion
+			//    marker, so detect it and no-op.
+			var legacyUserIDColumns int64
+			if err := db.Raw(`
+				SELECT count(*) FROM information_schema.columns
+				WHERE table_name = 'refresh_tokens' AND column_name = 'user_id'
+			`).Scan(&legacyUserIDColumns).Error; err != nil {
+				return err
+			}
+			if legacyUserIDColumns == 0 {
+				return nil
+			}
+
 			// 1. Add session_id to refresh_tokens, nullable for the backfill.
 			if err := db.Exec(
 				`ALTER TABLE refresh_tokens ADD COLUMN IF NOT EXISTS session_id UUID`,

--- a/services/main/init/migration/main.go
+++ b/services/main/init/migration/main.go
@@ -48,6 +48,7 @@ func updateMigration(db *gorm.DB) error {
 		&models.MaintenanceRequest{},
 		&models.MaintenanceRequestActivityLog{},
 		&models.MaintenanceRequestComment{},
+		&models.MaintenanceRequestAsset{},
 		&models.Expense{},
 		&models.Agreement{},
 		&models.AgreementAcceptance{},
@@ -126,6 +127,7 @@ func ServiceAutoMigration(db *gorm.DB) error {
 		jobs.FixLeaseMoveOutDateFrequencyMismatch(),
 		jobs.AddPropertyArchiveFields(),
 		jobs.SplitSessionsFromRefreshTokens(),
+		jobs.AddMaintenanceRequestAssets(),
 	})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("[Migration.Migrate]: %v", err)

--- a/services/main/internal/handlers/maintenance-request.go
+++ b/services/main/internal/handlers/maintenance-request.go
@@ -29,13 +29,17 @@ func NewMaintenanceRequestHandler(
 // ─── Request Bodies ───────────────────────────────────────────────────────────
 
 type CreateMaintenanceRequestBody struct {
-	UnitID      string   `json:"unit_id"     validate:"required,uuid4"`
-	Title       string   `json:"title"       validate:"required"`
-	Description string   `json:"description" validate:"required"`
-	Priority    string   `json:"priority"    validate:"required,oneof=LOW MEDIUM HIGH EMERGENCY"`
-	Category    string   `json:"category"    validate:"required"`
-	Visibility  string   `json:"visibility"  validate:"required,oneof=TENANT_VISIBLE INTERNAL_ONLY"`
-	Attachments []string `json:"attachments" validate:"omitempty"`
+	// At least one of UnitIDs / BlockIDs must be non-empty. That rule cannot be
+	// expressed in struct tags, so the service enforces it.
+	UnitIDs                []string `json:"unit_ids"                 validate:"omitempty,dive,uuid4"`
+	BlockIDs               []string `json:"block_ids"                validate:"omitempty,dive,uuid4"`
+	CreateSeparateRequests bool     `json:"create_separate_requests"`
+	Title                  string   `json:"title"                    validate:"required"`
+	Description            string   `json:"description"              validate:"required"`
+	Priority               string   `json:"priority"                 validate:"required,oneof=LOW MEDIUM HIGH EMERGENCY"`
+	Category               string   `json:"category"                 validate:"required"`
+	Visibility             string   `json:"visibility"               validate:"required,oneof=TENANT_VISIBLE INTERNAL_ONLY"`
+	Attachments            []string `json:"attachments"              validate:"omitempty"`
 }
 
 type UpdateMaintenanceRequestBody struct {
@@ -86,19 +90,22 @@ type TenantCreateMaintenanceRequestBody struct {
 
 // Create godoc
 //
-//	@Summary		Create a maintenance request (Admin)
-//	@Description	Create a new maintenance request (Admin)
+//	@Summary		Create maintenance request(s) (Admin)
+//	@Description	Create maintenance request(s) against one or more units and/or blocks (Admin).
+//	@Description	Always responds with an array: one request normally, or one per selected asset
+//	@Description	when create_separate_requests is true. A request covering more than one asset,
+//	@Description	or any block, is forced to INTERNAL_ONLY.
 //	@Tags			MaintenanceRequests
 //	@Accept			json
 //	@Produce		json
 //	@Security		BearerAuth
-//	@Param			property_id	path		string														true	"Property ID"
-//	@Param			body		body		CreateMaintenanceRequestBody								true	"Request details"
-//	@Success		201			{object}	object{data=transformations.AdminOutputMaintenanceRequest}	"Maintenance request created successfully"
-//	@Failure		400			{object}	lib.HTTPError												"Error occurred when creating maintenance request"
-//	@Failure		401			{object}	string														"Invalid or absent authentication token"
-//	@Failure		422			{object}	lib.HTTPError												"Validation error"
-//	@Failure		500			{object}	string														"An unexpected error occurred"
+//	@Param			property_id	path		string															true	"Property ID"
+//	@Param			body		body		CreateMaintenanceRequestBody									true	"Request details"
+//	@Success		201			{object}	object{data=[]transformations.AdminOutputMaintenanceRequest}	"Maintenance request(s) created successfully"
+//	@Failure		400			{object}	lib.HTTPError													"Error occurred when creating maintenance request"
+//	@Failure		401			{object}	string															"Invalid or absent authentication token"
+//	@Failure		422			{object}	lib.HTTPError													"Validation error"
+//	@Failure		500			{object}	string															"An unexpected error occurred"
 //	@Router			/api/v1/admin/clients/{client_id}/properties/{property_id}/maintenance-requests [post]
 func (h *MaintenanceRequestHandler) Create(w http.ResponseWriter, r *http.Request) {
 	currentUser, ok := lib.ClientUserFromContext(r.Context())
@@ -116,24 +123,35 @@ func (h *MaintenanceRequestHandler) Create(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	mr, err := h.service.CreateByAdmin(r.Context(), services.CreateMaintenanceRequestByAdminInput{
-		UnitID:       body.UnitID,
-		ClientUserID: currentUser.ID,
-		Title:        body.Title,
-		Desc:         body.Description,
-		Priority:     body.Priority,
-		Category:     body.Category,
-		Visibility:   body.Visibility,
-		Attachments:  body.Attachments,
+	requests, err := h.service.CreateByAdmin(r.Context(), services.CreateMaintenanceRequestByAdminInput{
+		PropertyID:             chi.URLParam(r, "property_id"),
+		UnitIDs:                body.UnitIDs,
+		BlockIDs:               body.BlockIDs,
+		CreateSeparateRequests: body.CreateSeparateRequests,
+		ClientUserID:           currentUser.ID,
+		Title:                  body.Title,
+		Desc:                   body.Description,
+		Priority:               body.Priority,
+		Category:               body.Category,
+		Visibility:             body.Visibility,
+		Attachments:            body.Attachments,
 	})
 	if err != nil {
 		HandleErrorResponse(w, err)
 		return
 	}
 
+	// Always an array: one entry normally, one per asset when the caller asked
+	// for separate requests. A shape that varies by request flag would break
+	// clients silently.
+	output := make([]any, len(requests))
+	for i := range requests {
+		output[i] = transformations.DBMaintenanceRequestToRest(&requests[i])
+	}
+
 	w.WriteHeader(http.StatusCreated)
 	json.NewEncoder(w).Encode(map[string]any{
-		"data": transformations.DBMaintenanceRequestToRest(mr),
+		"data": output,
 	})
 }
 
@@ -145,6 +163,7 @@ type ListMaintenanceRequestsQuery struct {
 	AssignedWorkerID  *string  `json:"assigned_worker_id"  query:"assigned_worker_id"  description:"Filter by assigned worker UUID"`
 	AssignedManagerID *string  `json:"assigned_manager_id" query:"assigned_manager_id" description:"Filter by assigned manager UUID"`
 	UnitIDs           []string `json:"unit_id"             query:"unit_id"             description:"Filter by one or more unit UUIDs"                                   collectionFormat:"multi" validate:"omitempty,dive,uuid4"`
+	BlockIDs          []string `json:"block_id"            query:"block_id"            description:"Filter by one or more property block UUIDs"                         collectionFormat:"multi" validate:"omitempty,dive,uuid4"`
 	LeaseID           *string  `json:"lease_id"            query:"lease_id"            description:"Filter by lease UUID"                                                                        validate:"omitempty,uuid4"`
 	TenantID          *string  `json:"tenant_id"           query:"tenant_id"           description:"Filter by tenant UUID"                                                                       validate:"omitempty,uuid4"`
 }
@@ -189,6 +208,7 @@ func (h *MaintenanceRequestHandler) List(w http.ResponseWriter, r *http.Request)
 		AssignedManagerID: lib.NullOrString(r.URL.Query().Get("assigned_manager_id")),
 		PropertyIDs:       &propertyIDs,
 		UnitIDs:           lib.NullOrStringArray(r.URL.Query()["unit_id"]),
+		BlockIDs:          lib.NullOrStringArray(r.URL.Query()["block_id"]),
 		LeaseID:           lib.NullOrString(r.URL.Query().Get("lease_id")),
 		TenantID:          lib.NullOrString(r.URL.Query().Get("tenant_id")),
 	}
@@ -256,6 +276,7 @@ func (h *MaintenanceRequestHandler) ListAcrossProperties(w http.ResponseWriter, 
 		AssignedWorkerID:  lib.NullOrString(r.URL.Query().Get("assigned_worker_id")),
 		AssignedManagerID: lib.NullOrString(r.URL.Query().Get("assigned_manager_id")),
 		UnitIDs:           lib.NullOrStringArray(r.URL.Query()["unit_id"]),
+		BlockIDs:          lib.NullOrStringArray(r.URL.Query()["block_id"]),
 		LeaseID:           lib.NullOrString(r.URL.Query().Get("lease_id")),
 		TenantID:          lib.NullOrString(r.URL.Query().Get("tenant_id")),
 	}

--- a/services/main/internal/models/maintenance-request.go
+++ b/services/main/internal/models/maintenance-request.go
@@ -15,8 +15,10 @@ type MaintenanceRequest struct {
 	BaseModelSoftDelete
 	Code string `gorm:"not null;uniqueIndex;"` // unique maintenance request code
 
-	UnitID string `gorm:"not null;index;"`
-	Unit   Unit
+	PropertyID string `gorm:"not null;index;"`
+	Property   Property
+
+	Assets []MaintenanceRequestAsset
 
 	// should only exist if user created it
 	LeaseID *string
@@ -70,6 +72,24 @@ func (mr *MaintenanceRequest) BeforeCreate(tx *gorm.DB) error {
 	}
 	mr.Code = *uniqueCode
 	return nil
+}
+
+// MaintenanceRequestAsset links a maintenance request to one asset it concerns.
+// Exactly one of UnitID / PropertyBlockID is set, matching AssetType. That rule
+// is enforced by a CHECK constraint added in the migration, because the Go type
+// alone cannot express it.
+type MaintenanceRequestAsset struct {
+	BaseModelSoftDelete
+	MaintenanceRequestID string `gorm:"not null;index;"`
+	MaintenanceRequest   MaintenanceRequest
+
+	AssetType string `gorm:"not null;index;"` // UNIT | BLOCK
+
+	UnitID *string
+	Unit   *Unit
+
+	PropertyBlockID *string
+	PropertyBlock   *PropertyBlock
 }
 
 type MaintenanceRequestComment struct {

--- a/services/main/internal/repository/maintenance-request.go
+++ b/services/main/internal/repository/maintenance-request.go
@@ -78,6 +78,7 @@ type ListMaintenanceRequestsFilter struct {
 	PropertyIDs       *[]string
 	ClientUserID      *string
 	UnitIDs           *[]string
+	BlockIDs          *[]string
 	LeaseID           *string
 	Statuses          []string
 	Priority          *string
@@ -142,6 +143,7 @@ func (r *maintenanceRequestRepository) List(
 			mrPropertyIDsScope(filters.PropertyIDs),
 			mrClientUserAccessScope(filters.ClientUserID),
 			mrUnitIDsScope(filters.UnitIDs),
+			mrBlockIDsScope(filters.BlockIDs),
 			mrLeaseIDScope(filters.LeaseID),
 			mrStatusScope(filters.Statuses),
 			mrPriorityScope(filters.Priority),
@@ -182,6 +184,7 @@ func (r *maintenanceRequestRepository) Count(
 			mrPropertyIDsScope(filters.PropertyIDs),
 			mrClientUserAccessScope(filters.ClientUserID),
 			mrUnitIDsScope(filters.UnitIDs),
+			mrBlockIDsScope(filters.BlockIDs),
 			mrLeaseIDScope(filters.LeaseID),
 			mrStatusScope(filters.Statuses),
 			mrPriorityScope(filters.Priority),
@@ -413,11 +416,10 @@ func mrClientIDScope(clientID *string) func(db *gorm.DB) *gorm.DB {
 			return db
 		}
 		subQuery := db.Session(&gorm.Session{NewDB: true}).
-			Table("units").
-			Select("units.id").
-			Joins("JOIN properties ON properties.id = units.property_id").
-			Where("properties.client_id = ? AND units.deleted_at IS NULL AND properties.deleted_at IS NULL", *clientID)
-		return db.Where("maintenance_requests.unit_id IN (?)", subQuery)
+			Table("properties").
+			Select("properties.id").
+			Where("properties.client_id = ? AND properties.deleted_at IS NULL", *clientID)
+		return db.Where("maintenance_requests.property_id IN (?)", subQuery)
 	}
 }
 
@@ -426,14 +428,10 @@ func mrClientUserAccessScope(clientUserID *string) func(db *gorm.DB) *gorm.DB {
 		if clientUserID == nil {
 			return db
 		}
-		unitsSubQuery := db.Session(&gorm.Session{NewDB: true}).
-			Table("units").
-			Select("id").
-			Where(
-				"property_id IN (?) AND deleted_at IS NULL",
-				accessiblePropertyIDsSubQuery(db, *clientUserID),
-			)
-		return db.Where("maintenance_requests.unit_id IN (?)", unitsSubQuery)
+		return db.Where(
+			"maintenance_requests.property_id IN (?)",
+			accessiblePropertyIDsSubQuery(db, *clientUserID),
+		)
 	}
 }
 
@@ -442,20 +440,46 @@ func mrPropertyIDsScope(propertyIDs *[]string) func(db *gorm.DB) *gorm.DB {
 		if propertyIDs == nil {
 			return db
 		}
-		subQuery := db.Session(&gorm.Session{NewDB: true}).
-			Table("units").
-			Select("id").
-			Where("property_id IN (?) AND deleted_at IS NULL", *propertyIDs)
-		return db.Where("maintenance_requests.unit_id IN (?)", subQuery)
+		return db.Where("maintenance_requests.property_id IN (?)", *propertyIDs)
 	}
 }
 
+// mrUnitIDsScope matches requests that target any of the given units. EXISTS
+// rather than a join, so a request targeting two of the selected units is still
+// returned exactly once.
 func mrUnitIDsScope(unitIDs *[]string) func(db *gorm.DB) *gorm.DB {
 	return func(db *gorm.DB) *gorm.DB {
 		if unitIDs == nil {
 			return db
 		}
-		return db.Where("maintenance_requests.unit_id IN (?)", *unitIDs)
+		return db.Where(
+			`EXISTS (
+				SELECT 1 FROM maintenance_request_assets a
+				WHERE a.maintenance_request_id = maintenance_requests.id
+				  AND a.asset_type = 'UNIT'
+				  AND a.unit_id IN (?)
+				  AND a.deleted_at IS NULL
+			)`,
+			*unitIDs,
+		)
+	}
+}
+
+func mrBlockIDsScope(blockIDs *[]string) func(db *gorm.DB) *gorm.DB {
+	return func(db *gorm.DB) *gorm.DB {
+		if blockIDs == nil {
+			return db
+		}
+		return db.Where(
+			`EXISTS (
+				SELECT 1 FROM maintenance_request_assets a
+				WHERE a.maintenance_request_id = maintenance_requests.id
+				  AND a.asset_type = 'BLOCK'
+				  AND a.property_block_id IN (?)
+				  AND a.deleted_at IS NULL
+			)`,
+			*blockIDs,
+		)
 	}
 }
 
@@ -611,6 +635,7 @@ func (r *maintenanceRequestRepository) CountByStatus(
 			mrPropertyIDsScope(filters.PropertyIDs),
 			mrClientUserAccessScope(filters.ClientUserID),
 			mrUnitIDsScope(filters.UnitIDs),
+			mrBlockIDsScope(filters.BlockIDs),
 			mrLeaseIDScope(filters.LeaseID),
 			mrTenantScope(filters.TenantID),
 		).

--- a/services/main/internal/services/expense.go
+++ b/services/main/internal/services/expense.go
@@ -339,7 +339,7 @@ func (s *expenseService) GenerateExpenseInvoice(
 
 		mr, mrErr := s.mrRepo.GetOneWithPopulate(ctx, repository.GetMaintenanceRequestQuery{
 			ID:       *expense.ContextMaintenanceRequestID,
-			Populate: &[]string{"Lease", "Lease.Tenant", "Unit"},
+			Populate: &[]string{"Lease", "Lease.Tenant"},
 		})
 		if mrErr != nil {
 			tx.Rollback()
@@ -355,7 +355,7 @@ func (s *expenseService) GenerateExpenseInvoice(
 			})
 		}
 
-		propertyID := mr.Unit.PropertyID
+		propertyID := mr.PropertyID
 		lineItem.Metadata = &map[string]any{"mr": mr.ID.String()}
 
 		for _, payer := range input.Payers {

--- a/services/main/internal/services/maintenance-request-planner.go
+++ b/services/main/internal/services/maintenance-request-planner.go
@@ -1,0 +1,97 @@
+package services
+
+import "github.com/Bendomey/rent-loop/services/main/pkg"
+
+const (
+	MaintenanceAssetTypeUnit  = "UNIT"
+	MaintenanceAssetTypeBlock = "BLOCK"
+
+	MaintenanceVisibilityTenantVisible = "TENANT_VISIBLE"
+	MaintenanceVisibilityInternalOnly  = "INTERNAL_ONLY"
+)
+
+// MaintenanceAssetRef names one asset a maintenance request targets.
+type MaintenanceAssetRef struct {
+	Type string // UNIT | BLOCK
+	ID   string
+}
+
+// PlannedMaintenanceRequest describes one request that should be created.
+type PlannedMaintenanceRequest struct {
+	Assets     []MaintenanceAssetRef
+	Visibility string
+}
+
+// PlanMaintenanceRequests turns a landlord's asset selection into the set of
+// requests to create, resolving each one's effective visibility.
+//
+// When fanOut is true, every selected asset becomes its own single-asset
+// request. That is the path that keeps tenants informed, because each unit
+// request is then narrow enough to stay tenant-visible.
+func PlanMaintenanceRequests(
+	unitIDs []string,
+	blockIDs []string,
+	requestedVisibility string,
+	fanOut bool,
+) ([]PlannedMaintenanceRequest, error) {
+	assets := collectAssets(unitIDs, blockIDs)
+
+	if len(assets) == 0 {
+		return nil, pkg.BadRequestError("select at least one unit or block", nil)
+	}
+
+	if fanOut {
+		planned := make([]PlannedMaintenanceRequest, 0, len(assets))
+		for _, asset := range assets {
+			single := []MaintenanceAssetRef{asset}
+			planned = append(planned, PlannedMaintenanceRequest{
+				Assets:     single,
+				Visibility: resolveMaintenanceVisibility(single, requestedVisibility),
+			})
+		}
+		return planned, nil
+	}
+
+	return []PlannedMaintenanceRequest{{
+		Assets:     assets,
+		Visibility: resolveMaintenanceVisibility(assets, requestedVisibility),
+	}}, nil
+}
+
+// collectAssets flattens the two id lists into one ordered, deduplicated slice.
+// A repeated id would otherwise violate the partial unique index on the assets
+// table, or in fan-out mode create two identical requests.
+func collectAssets(unitIDs, blockIDs []string) []MaintenanceAssetRef {
+	assets := make([]MaintenanceAssetRef, 0, len(unitIDs)+len(blockIDs))
+	seen := map[MaintenanceAssetRef]bool{}
+
+	appendUnique := func(assetType string, ids []string) {
+		for _, id := range ids {
+			if id == "" {
+				continue
+			}
+			ref := MaintenanceAssetRef{Type: assetType, ID: id}
+			if seen[ref] {
+				continue
+			}
+			seen[ref] = true
+			assets = append(assets, ref)
+		}
+	}
+
+	appendUnique(MaintenanceAssetTypeUnit, unitIDs)
+	appendUnique(MaintenanceAssetTypeBlock, blockIDs)
+
+	return assets
+}
+
+// resolveMaintenanceVisibility downgrades anything broader than a single unit to
+// INTERNAL_ONLY. A single unit is the only shape with one lease to resolve and
+// one tenant to notify. Downgrading silently mirrors the existing behaviour in
+// CreateByAdmin when a unit has no active lease.
+func resolveMaintenanceVisibility(assets []MaintenanceAssetRef, requested string) string {
+	if len(assets) == 1 && assets[0].Type == MaintenanceAssetTypeUnit {
+		return requested
+	}
+	return MaintenanceVisibilityInternalOnly
+}

--- a/services/main/internal/services/maintenance-request-planner_test.go
+++ b/services/main/internal/services/maintenance-request-planner_test.go
@@ -1,0 +1,118 @@
+package services
+
+import "testing"
+
+// A single unit is the only shape with one lease to resolve and one tenant to
+// notify, so it is the only shape allowed to stay tenant-visible.
+func TestPlanKeepsTenantVisibleForSingleUnit(t *testing.T) {
+	planned, err := PlanMaintenanceRequests([]string{"unit-1"}, nil, "TENANT_VISIBLE", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(planned) != 1 {
+		t.Fatalf("got %d requests, want 1", len(planned))
+	}
+	if planned[0].Visibility != "TENANT_VISIBLE" {
+		t.Errorf("got visibility %q, want TENANT_VISIBLE", planned[0].Visibility)
+	}
+	if len(planned[0].Assets) != 1 || planned[0].Assets[0].Type != "UNIT" {
+		t.Errorf("got assets %+v, want a single UNIT asset", planned[0].Assets)
+	}
+}
+
+func TestPlanForcesInternalForMultipleUnits(t *testing.T) {
+	planned, err := PlanMaintenanceRequests([]string{"unit-1", "unit-2"}, nil, "TENANT_VISIBLE", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(planned) != 1 {
+		t.Fatalf("got %d requests, want 1", len(planned))
+	}
+	if planned[0].Visibility != "INTERNAL_ONLY" {
+		t.Errorf("got visibility %q, want INTERNAL_ONLY", planned[0].Visibility)
+	}
+}
+
+// A block is common-area work with no lease behind it, so even one block on its
+// own cannot be tenant-visible.
+func TestPlanForcesInternalForSingleBlock(t *testing.T) {
+	planned, err := PlanMaintenanceRequests(nil, []string{"block-1"}, "TENANT_VISIBLE", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if planned[0].Visibility != "INTERNAL_ONLY" {
+		t.Errorf("got visibility %q, want INTERNAL_ONLY", planned[0].Visibility)
+	}
+}
+
+func TestPlanForcesInternalWhenBlockAccompaniesSingleUnit(t *testing.T) {
+	planned, err := PlanMaintenanceRequests([]string{"unit-1"}, []string{"block-1"}, "TENANT_VISIBLE", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if planned[0].Visibility != "INTERNAL_ONLY" {
+		t.Errorf("got visibility %q, want INTERNAL_ONLY", planned[0].Visibility)
+	}
+	if len(planned[0].Assets) != 2 {
+		t.Errorf("got %d assets, want 2", len(planned[0].Assets))
+	}
+}
+
+// Fan-out is the path that keeps tenants informed: each unit becomes its own
+// single-unit request and so may stay tenant-visible, while each block request
+// is still internal.
+func TestPlanFansOutOneRequestPerAsset(t *testing.T) {
+	planned, err := PlanMaintenanceRequests(
+		[]string{"unit-1", "unit-2"}, []string{"block-1"}, "TENANT_VISIBLE", true,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(planned) != 3 {
+		t.Fatalf("got %d requests, want 3", len(planned))
+	}
+	for _, p := range planned {
+		if len(p.Assets) != 1 {
+			t.Fatalf("got %d assets on a fanned-out request, want 1", len(p.Assets))
+		}
+		want := "TENANT_VISIBLE"
+		if p.Assets[0].Type == "BLOCK" {
+			want = "INTERNAL_ONLY"
+		}
+		if p.Visibility != want {
+			t.Errorf("asset %+v got visibility %q, want %q", p.Assets[0], p.Visibility, want)
+		}
+	}
+}
+
+func TestPlanHonoursExplicitInternalOnlyForSingleUnit(t *testing.T) {
+	planned, err := PlanMaintenanceRequests([]string{"unit-1"}, nil, "INTERNAL_ONLY", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if planned[0].Visibility != "INTERNAL_ONLY" {
+		t.Errorf("got visibility %q, want INTERNAL_ONLY", planned[0].Visibility)
+	}
+}
+
+func TestPlanRejectsEmptySelection(t *testing.T) {
+	if _, err := PlanMaintenanceRequests(nil, nil, "TENANT_VISIBLE", false); err == nil {
+		t.Error("expected an error when no unit or block is selected")
+	}
+}
+
+// A repeated id would otherwise violate the partial unique index, or in fan-out
+// mode silently create two identical requests.
+func TestPlanDeduplicatesRepeatedIDs(t *testing.T) {
+	planned, err := PlanMaintenanceRequests([]string{"unit-1", "unit-1"}, nil, "TENANT_VISIBLE", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(planned[0].Assets) != 1 {
+		t.Fatalf("got %d assets, want 1 after dedupe", len(planned[0].Assets))
+	}
+	// Deduped down to a single unit, so it is allowed to stay tenant-visible.
+	if planned[0].Visibility != "TENANT_VISIBLE" {
+		t.Errorf("got visibility %q, want TENANT_VISIBLE", planned[0].Visibility)
+	}
+}

--- a/services/main/internal/services/maintenance-request.go
+++ b/services/main/internal/services/maintenance-request.go
@@ -18,7 +18,7 @@ import (
 
 type MaintenanceRequestService interface {
 	CreateByTenant(ctx context.Context, input CreateMaintenanceRequestByTenantInput) (*models.MaintenanceRequest, error)
-	CreateByAdmin(ctx context.Context, input CreateMaintenanceRequestByAdminInput) (*models.MaintenanceRequest, error)
+	CreateByAdmin(ctx context.Context, input CreateMaintenanceRequestByAdminInput) ([]models.MaintenanceRequest, error)
 	GetMaintenanceRequest(
 		ctx context.Context,
 		query repository.GetMaintenanceRequestQuery,
@@ -111,14 +111,17 @@ type CreateMaintenanceRequestByTenantInput struct {
 }
 
 type CreateMaintenanceRequestByAdminInput struct {
-	UnitID       string
-	ClientUserID string
-	Title        string
-	Desc         string
-	Priority     string
-	Category     string
-	Visibility   string
-	Attachments  []string
+	PropertyID             string
+	UnitIDs                []string
+	BlockIDs               []string
+	CreateSeparateRequests bool
+	ClientUserID           string
+	Title                  string
+	Desc                   string
+	Priority               string
+	Category               string
+	Visibility             string
+	Attachments            []string
 }
 
 type UpdateMaintenanceRequestInput struct {
@@ -186,7 +189,10 @@ func (s *maintenanceRequestService) CreateByTenant(
 	}
 
 	mr := &models.MaintenanceRequest{
-		UnitID:            lease.UnitId,
+		PropertyID: lease.Unit.PropertyID,
+		Assets: []models.MaintenanceRequestAsset{
+			{AssetType: MaintenanceAssetTypeUnit, UnitID: &lease.UnitId},
+		},
 		LeaseID:           &input.LeaseID,
 		CreatedByTenantID: &input.TenantID,
 		Title:             input.Title,
@@ -246,101 +252,197 @@ func (s *maintenanceRequestService) CreateByTenant(
 func (s *maintenanceRequestService) CreateByAdmin(
 	ctx context.Context,
 	input CreateMaintenanceRequestByAdminInput,
-) (*models.MaintenanceRequest, error) {
-	var createdByTenantID *string = nil
-	unitID := input.UnitID
+) ([]models.MaintenanceRequest, error) {
+	planned, err := PlanMaintenanceRequests(
+		input.UnitIDs, input.BlockIDs, input.Visibility, input.CreateSeparateRequests,
+	)
+	if err != nil {
+		return nil, err
+	}
 
-	var leaseID *string = nil
+	// Validate the full selection once, before creating anything.
+	for _, plan := range planned {
+		if err := s.validateAssetsBelongToProperty(ctx, input.PropertyID, plan.Assets); err != nil {
+			return nil, err
+		}
+	}
 
-	if input.Visibility == "TENANT_VISIBLE" {
-		// try to find an active lease connected to unitId
-		lease, err := s.leaseRepo.GetActiveLeaseByUnitID(ctx, input.UnitID)
-		if err != nil {
-			if err == gorm.ErrRecordNotFound {
-				// if there is no lease, then we should allow only internal admins to see it.
-				input.Visibility = "INTERNAL_ONLY"
+	created := make([]models.MaintenanceRequest, 0, len(planned))
+
+	for _, plan := range planned {
+		mr := &models.MaintenanceRequest{
+			PropertyID:            input.PropertyID,
+			CreatedByClientUserID: &input.ClientUserID,
+			Title:                 input.Title,
+			Description:           input.Desc,
+			Priority:              input.Priority,
+			Category:              input.Category,
+			Attachments:           input.Attachments,
+			Status:                "NEW",
+			Visibility:            plan.Visibility,
+			Assets:                buildAssetRows(plan.Assets),
+			ActivityLogs: []models.MaintenanceRequestActivityLog{
+				{
+					Action:                  "CREATED",
+					PerformedByClientUserID: &input.ClientUserID,
+				},
+			},
+		}
+
+		// Only a single-unit request has one lease to resolve and one tenant to
+		// notify. Anything broader was already forced to INTERNAL_ONLY by the
+		// planner, so there is nothing to resolve.
+		if mr.Visibility == MaintenanceVisibilityTenantVisible {
+			lease, leaseErr := s.leaseRepo.GetActiveLeaseByUnitID(ctx, plan.Assets[0].ID)
+			switch {
+			case leaseErr == gorm.ErrRecordNotFound:
+				// No tenant to show it to, so keep it internal.
+				mr.Visibility = MaintenanceVisibilityInternalOnly
+			case leaseErr != nil:
+				return nil, pkg.InternalServerError(leaseErr.Error(), &pkg.RentLoopErrorParams{
+					Err: leaseErr,
+					Metadata: map[string]string{
+						"function": "CreateByAdmin",
+						"action":   "fetching lease to resolve tenant and unit",
+					},
+				})
+			default:
+				leaseID := lease.ID.String()
+				mr.LeaseID = &leaseID
+				mr.CreatedByTenantID = &lease.TenantId
 			}
+		}
+
+		if err := s.repo.Create(ctx, mr); err != nil {
 			return nil, pkg.InternalServerError(err.Error(), &pkg.RentLoopErrorParams{
 				Err: err,
 				Metadata: map[string]string{
 					"function": "CreateByAdmin",
-					"action":   "fetching lease to resolve tenant and unit",
+					"action":   "creating maintenance request",
 				},
 			})
-		} else {
-			leaseIDString := lease.ID.String()
-			leaseID = &leaseIDString
-			createdByTenantID = &lease.TenantId
 		}
 
+		s.notifyTenantOfNewRequest(ctx, mr, input.Title)
+
+		created = append(created, *mr)
 	}
 
-	mr := &models.MaintenanceRequest{
-		UnitID:                unitID,
-		LeaseID:               leaseID,
-		CreatedByClientUserID: &input.ClientUserID,
-		CreatedByTenantID:     createdByTenantID,
-		Title:                 input.Title,
-		Description:           input.Desc,
-		Priority:              input.Priority,
-		Category:              input.Category,
-		Attachments:           input.Attachments,
-		Status:                "NEW",
-		Visibility:            input.Visibility,
-		ActivityLogs: []models.MaintenanceRequestActivityLog{
-			{
-				Action:                  "CREATED",
-				PerformedByClientUserID: &input.ClientUserID,
-			},
+	return created, nil
+}
+
+// notifyTenantOfNewRequest pushes to the tenant when a request was created on
+// their behalf. No-op unless the request resolved to a single tenant's lease.
+func (s *maintenanceRequestService) notifyTenantOfNewRequest(
+	ctx context.Context,
+	mr *models.MaintenanceRequest,
+	title string,
+) {
+	if mr.CreatedByTenantID == nil || mr.LeaseID == nil {
+		return
+	}
+
+	tenantAccount, err := s.tenantAccountRepo.FindOne(ctx, map[string]any{
+		"tenant_id": *mr.CreatedByTenantID,
+	})
+	if err != nil || tenantAccount == nil {
+		log.WithError(err).WithField("tenantID", *mr.CreatedByTenantID).
+			Warn("[MaintenanceRequest] could not resolve tenant account for notification")
+		raven.CaptureError(err, map[string]string{
+			"function":               "CreateByAdmin",
+			"action":                 "resolving tenant account for notification",
+			"tenant_id":              *mr.CreatedByTenantID,
+			"maintenance_request_id": mr.ID.String(),
+		})
+		return
+	}
+
+	tenantAccountID := tenantAccount.ID.String()
+	if err := s.notificationService.SendToTenantAccount(
+		ctx,
+		tenantAccountID,
+		"New maintenance request",
+		"A new maintenance request has been created on your behalf: "+title,
+		map[string]string{
+			"type":                   "MAINTENANCE",
+			"maintenance_request_id": mr.ID.String(),
+			"status":                 "NEW",
+			"lease_id":               *mr.LeaseID,
 		},
-	}
-
-	if err := s.repo.Create(ctx, mr); err != nil {
-		return nil, pkg.InternalServerError(err.Error(), &pkg.RentLoopErrorParams{
-			Err: err,
-			Metadata: map[string]string{
-				"function": "CreateByAdmin",
-				"action":   "creating maintenance request",
-			},
+	); err != nil {
+		log.WithError(err).WithField("tenantAccountID", tenantAccountID).
+			Warn("[MaintenanceRequest] push notification failed")
+		raven.CaptureError(err, map[string]string{
+			"function":               "CreateByAdmin",
+			"action":                 "sending push notification",
+			"tenant_id":              *mr.CreatedByTenantID,
+			"maintenance_request_id": mr.ID.String(),
 		})
 	}
+}
 
-	// lets send push notification to tenant that an MR was created on their behalf
-	if createdByTenantID != nil && mr.LeaseID != nil {
-		tenantAccount, err := s.tenantAccountRepo.FindOne(ctx, map[string]any{
-			"tenant_id": *createdByTenantID,
-		})
+// validateAssetsBelongToProperty rejects any unit or block that is not part of
+// the property the request is being created under. Without this a caller could
+// attach another client's unit to their own request.
+func (s *maintenanceRequestService) validateAssetsBelongToProperty(
+	ctx context.Context,
+	propertyID string,
+	assets []MaintenanceAssetRef,
+) error {
+	db := lib.ResolveDB(ctx, s.appCtx.DB).WithContext(ctx)
 
-		if err != nil || tenantAccount == nil {
-			log.WithError(err).WithField("tenantID", *createdByTenantID).
-				Warn("[MaintenanceRequest] could not resolve tenant account for notification")
-			raven.CaptureError(err, map[string]string{
-				"function":               "CreateByAdmin",
-				"action":                 "resolving tenant account for notification",
-				"tenant_id":              *createdByTenantID,
-				"maintenance_request_id": mr.ID.String(),
+	for _, asset := range assets {
+		var count int64
+		var err error
+
+		switch asset.Type {
+		case MaintenanceAssetTypeUnit:
+			err = db.Table("units").
+				Where("id = ? AND property_id = ? AND deleted_at IS NULL", asset.ID, propertyID).
+				Count(&count).Error
+		case MaintenanceAssetTypeBlock:
+			err = db.Table("property_blocks").
+				Where("id = ? AND property_id = ? AND deleted_at IS NULL", asset.ID, propertyID).
+				Count(&count).Error
+		default:
+			return pkg.BadRequestError("unknown asset type "+asset.Type, nil)
+		}
+
+		if err != nil {
+			return pkg.InternalServerError(err.Error(), &pkg.RentLoopErrorParams{
+				Err: err,
+				Metadata: map[string]string{
+					"function": "validateAssetsBelongToProperty",
+					"action":   "verifying asset belongs to property",
+				},
 			})
-		} else {
-			tenantAccountID := tenantAccount.ID.String()
-			if err := s.notificationService.SendToTenantAccount(ctx, tenantAccountID, "New maintenance request", "A new maintenance request has been created on your behalf: "+input.Title, map[string]string{
-				"type":                   "MAINTENANCE",
-				"maintenance_request_id": mr.ID.String(),
-				"status":                 "NEW",
-				"lease_id":               *mr.LeaseID,
-			}); err != nil {
-				log.WithError(err).WithField("tenantAccountID", tenantAccountID).
-					Warn("[MaintenanceRequest] push notification failed")
-				raven.CaptureError(err, map[string]string{
-					"function":               "CreateByAdmin",
-					"action":                 "sending push notification",
-					"tenant_id":              *createdByTenantID,
-					"maintenance_request_id": mr.ID.String(),
-				})
-			}
+		}
+
+		if count == 0 {
+			return pkg.BadRequestError(
+				asset.Type+" "+asset.ID+" does not belong to this property",
+				nil,
+			)
 		}
 	}
 
-	return mr, nil
+	return nil
+}
+
+// buildAssetRows converts planned asset references into model rows.
+func buildAssetRows(assets []MaintenanceAssetRef) []models.MaintenanceRequestAsset {
+	rows := make([]models.MaintenanceRequestAsset, 0, len(assets))
+	for _, asset := range assets {
+		id := asset.ID
+		row := models.MaintenanceRequestAsset{AssetType: asset.Type}
+		if asset.Type == MaintenanceAssetTypeUnit {
+			row.UnitID = &id
+		} else {
+			row.PropertyBlockID = &id
+		}
+		rows = append(rows, row)
+	}
+	return rows
 }
 
 // --- Get / List ---

--- a/services/main/internal/transformations/maintenance-request.go
+++ b/services/main/internal/transformations/maintenance-request.go
@@ -10,6 +10,7 @@ type AdminOutputMaintenanceRequest struct {
 	ID                    string                          `json:"id"`
 	Code                  string                          `json:"code"`
 	PropertyID            string                          `json:"property_id"`
+	Property              OutputProperty                  `json:"property,omitempty"`
 	Assets                []OutputMaintenanceRequestAsset `json:"assets"`
 	LeaseID               *string                         `json:"lease_id,omitempty"`
 	CreatedByTenantID     *string                         `json:"created_by_tenant_id,omitempty"`
@@ -106,6 +107,7 @@ func DBMaintenanceRequestToRest(mr *models.MaintenanceRequest) any {
 		"id":                        mr.ID.String(),
 		"code":                      mr.Code,
 		"property_id":               mr.PropertyID,
+		"property":                  DBPropertyToRest(&mr.Property),
 		"assets":                    assets,
 		"lease_id":                  mr.LeaseID,
 		"created_by_tenant_id":      mr.CreatedByTenantID,

--- a/services/main/internal/transformations/maintenance-request.go
+++ b/services/main/internal/transformations/maintenance-request.go
@@ -7,35 +7,73 @@ import (
 )
 
 type AdminOutputMaintenanceRequest struct {
-	ID                    string                         `json:"id"`
-	Code                  string                         `json:"code"`
-	UnitID                string                         `json:"unit_id"`
-	Unit                  AdminOutputUnit                `json:"unit,omitempty"`
-	LeaseID               *string                        `json:"lease_id,omitempty"`
-	CreatedByTenantID     *string                        `json:"created_by_tenant_id,omitempty"`
-	CreatedByTenant       *OutputAdminTenant             `json:"created_by_tenant,omitempty"`
-	CreatedByClientUserID *string                        `json:"created_by_client_user_id,omitempty"`
-	CreatedByClientUser   *OutputClientUser              `json:"created_by_client_user,omitempty"`
-	Title                 string                         `json:"title"`
-	Description           string                         `json:"description"`
-	Attachments           []string                       `json:"attachments"`
-	Priority              string                         `json:"priority"`
-	Category              string                         `json:"category"`
-	Status                string                         `json:"status"`
-	Visibility            string                         `json:"visibility"`
-	AssignedWorkerID      *string                        `json:"assigned_worker_id,omitempty"`
-	AssignedWorker        *OutputClientUser              `json:"assigned_worker,omitempty"`
-	AssignedManagerID     *string                        `json:"assigned_manager_id,omitempty"`
-	AssignedManager       *OutputClientUser              `json:"assigned_manager,omitempty"`
-	CancellationReason    *string                        `json:"cancellation_reason,omitempty"`
-	StartedAt             *time.Time                     `json:"started_at,omitempty"`
-	ReviewedAt            *time.Time                     `json:"reviewed_at,omitempty"`
-	ResolvedAt            *time.Time                     `json:"resolved_at,omitempty"`
-	CanceledAt            *time.Time                     `json:"canceled_at,omitempty"`
-	Expenses              []OutputExpense                `json:"expenses,omitempty"`
-	ActivityLogs          []OutputMaintenanceActivityLog `json:"activity_logs,omitempty"`
-	CreatedAt             time.Time                      `json:"created_at"`
-	UpdatedAt             time.Time                      `json:"updated_at"`
+	ID                    string                          `json:"id"`
+	Code                  string                          `json:"code"`
+	PropertyID            string                          `json:"property_id"`
+	Assets                []OutputMaintenanceRequestAsset `json:"assets"`
+	LeaseID               *string                         `json:"lease_id,omitempty"`
+	CreatedByTenantID     *string                         `json:"created_by_tenant_id,omitempty"`
+	CreatedByTenant       *OutputAdminTenant              `json:"created_by_tenant,omitempty"`
+	CreatedByClientUserID *string                         `json:"created_by_client_user_id,omitempty"`
+	CreatedByClientUser   *OutputClientUser               `json:"created_by_client_user,omitempty"`
+	Title                 string                          `json:"title"`
+	Description           string                          `json:"description"`
+	Attachments           []string                        `json:"attachments"`
+	Priority              string                          `json:"priority"`
+	Category              string                          `json:"category"`
+	Status                string                          `json:"status"`
+	Visibility            string                          `json:"visibility"`
+	AssignedWorkerID      *string                         `json:"assigned_worker_id,omitempty"`
+	AssignedWorker        *OutputClientUser               `json:"assigned_worker,omitempty"`
+	AssignedManagerID     *string                         `json:"assigned_manager_id,omitempty"`
+	AssignedManager       *OutputClientUser               `json:"assigned_manager,omitempty"`
+	CancellationReason    *string                         `json:"cancellation_reason,omitempty"`
+	StartedAt             *time.Time                      `json:"started_at,omitempty"`
+	ReviewedAt            *time.Time                      `json:"reviewed_at,omitempty"`
+	ResolvedAt            *time.Time                      `json:"resolved_at,omitempty"`
+	CanceledAt            *time.Time                      `json:"canceled_at,omitempty"`
+	Expenses              []OutputExpense                 `json:"expenses,omitempty"`
+	ActivityLogs          []OutputMaintenanceActivityLog  `json:"activity_logs,omitempty"`
+	CreatedAt             time.Time                       `json:"created_at"`
+	UpdatedAt             time.Time                       `json:"updated_at"`
+}
+
+type OutputMaintenanceRequestAsset struct {
+	ID              string  `json:"id"`
+	AssetType       string  `json:"asset_type"`
+	UnitID          *string `json:"unit_id,omitempty"`
+	Unit            any     `json:"unit,omitempty"`
+	PropertyBlockID *string `json:"property_block_id,omitempty"`
+	PropertyBlock   any     `json:"property_block,omitempty"`
+}
+
+// DBMaintenanceRequestAssetToRest transforms one asset row to its REST shape.
+// Exactly one of the unit / block pairs is populated, matching AssetType.
+func DBMaintenanceRequestAssetToRest(asset *models.MaintenanceRequestAsset) any {
+	if asset == nil {
+		return nil
+	}
+
+	output := map[string]any{
+		"id":         asset.ID.String(),
+		"asset_type": asset.AssetType,
+	}
+
+	if asset.UnitID != nil {
+		output["unit_id"] = *asset.UnitID
+		if asset.Unit != nil {
+			output["unit"] = DBAdminUnitToRest(asset.Unit)
+		}
+	}
+
+	if asset.PropertyBlockID != nil {
+		output["property_block_id"] = *asset.PropertyBlockID
+		if asset.PropertyBlock != nil {
+			output["property_block"] = DBPropertyBlockToRest(asset.PropertyBlock)
+		}
+	}
+
+	return output
 }
 
 // DBMaintenanceRequestToRest transforms a MaintenanceRequest model to its PM/admin REST representation.
@@ -59,11 +97,16 @@ func DBMaintenanceRequestToRest(mr *models.MaintenanceRequest) any {
 		expenses[i] = DBExpenseToRest(&mr.Expenses[i])
 	}
 
+	assets := make([]any, len(mr.Assets))
+	for i := range mr.Assets {
+		assets[i] = DBMaintenanceRequestAssetToRest(&mr.Assets[i])
+	}
+
 	return map[string]any{
 		"id":                        mr.ID.String(),
 		"code":                      mr.Code,
-		"unit_id":                   mr.UnitID,
-		"unit":                      DBAdminUnitToRest(&mr.Unit),
+		"property_id":               mr.PropertyID,
+		"assets":                    assets,
 		"lease_id":                  mr.LeaseID,
 		"created_by_tenant_id":      mr.CreatedByTenantID,
 		"created_by_tenant":         DBTenantToRest(mr.CreatedByTenant),
@@ -93,24 +136,24 @@ func DBMaintenanceRequestToRest(mr *models.MaintenanceRequest) any {
 }
 
 type OutputMaintenanceRequest struct {
-	ID                 string                         `json:"id"`
-	Code               string                         `json:"code"`
-	UnitID             string                         `json:"unit_id"`
-	Unit               OutputUnit                     `json:"unit,omitempty"`
-	Title              string                         `json:"title"`
-	Description        string                         `json:"description"`
-	Attachments        []string                       `json:"attachments"`
-	Priority           string                         `json:"priority"`
-	Category           string                         `json:"category"`
-	Status             string                         `json:"status"`
-	StartedAt          *time.Time                     `json:"started_at,omitempty"`
-	ResolvedAt         *time.Time                     `json:"resolved_at,omitempty"`
-	CanceledAt         *time.Time                     `json:"canceled_at,omitempty"`
-	CancellationReason *string                        `json:"cancellation_reason,omitempty"`
-	Expenses           []OutputExpense                `json:"expenses,omitempty"`
-	ActivityLogs       []OutputMaintenanceActivityLog `json:"activity_logs,omitempty"`
-	CreatedAt          time.Time                      `json:"created_at"`
-	UpdatedAt          time.Time                      `json:"updated_at"`
+	ID                 string                          `json:"id"`
+	Code               string                          `json:"code"`
+	PropertyID         string                          `json:"property_id"`
+	Assets             []OutputMaintenanceRequestAsset `json:"assets"`
+	Title              string                          `json:"title"`
+	Description        string                          `json:"description"`
+	Attachments        []string                        `json:"attachments"`
+	Priority           string                          `json:"priority"`
+	Category           string                          `json:"category"`
+	Status             string                          `json:"status"`
+	StartedAt          *time.Time                      `json:"started_at,omitempty"`
+	ResolvedAt         *time.Time                      `json:"resolved_at,omitempty"`
+	CanceledAt         *time.Time                      `json:"canceled_at,omitempty"`
+	CancellationReason *string                         `json:"cancellation_reason,omitempty"`
+	Expenses           []OutputExpense                 `json:"expenses,omitempty"`
+	ActivityLogs       []OutputMaintenanceActivityLog  `json:"activity_logs,omitempty"`
+	CreatedAt          time.Time                       `json:"created_at"`
+	UpdatedAt          time.Time                       `json:"updated_at"`
 }
 
 // DBMaintenanceRequestToTenantRest transforms a MaintenanceRequest to the tenant-facing representation.
@@ -134,10 +177,16 @@ func DBMaintenanceRequestToTenantRest(mr *models.MaintenanceRequest) any {
 		expenses[i] = DBExpenseToRest(&mr.Expenses[i])
 	}
 
+	assets := make([]any, len(mr.Assets))
+	for i := range mr.Assets {
+		assets[i] = DBMaintenanceRequestAssetToRest(&mr.Assets[i])
+	}
+
 	return map[string]any{
 		"id":                  mr.ID.String(),
 		"code":                mr.Code,
-		"unit_id":             mr.UnitID,
+		"property_id":         mr.PropertyID,
+		"assets":              assets,
 		"title":               mr.Title,
 		"description":         mr.Description,
 		"attachments":         attachments,


### PR DESCRIPTION
- Updated the migration to include MaintenanceRequestAsset model.
- Modified CreateMaintenanceRequestBody to accept multiple UnitIDs and BlockIDs.
- Adjusted CreateByAdmin method to handle multiple maintenance requests based on selected assets.
- Implemented asset validation to ensure they belong to the specified property.
- Enhanced transformations to include asset details in maintenance request responses.
- Added new service for planning maintenance requests, allowing for fan-out of requests based on selected assets.
- Updated tests to cover new functionality and ensure correct behavior for asset handling.
